### PR TITLE
Switch METAR source to NOAA

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,9 @@ Ensure you have the following installed before running the script:
     Install with: `winget install MPC-HC --id clsid2.mpc-hc`
   - **MPV**:  
     Install with: `scoop install mpv` or via [mpv.io](https://mpv.io/installation/)
-- **fzf** *(Optional, but recommended)*:  
+- **fzf** *(Optional, but recommended)*:
   Install with: `winget install --id=junegunn.fzf -e`
+- **Internet access to fetch METAR data** from the [NOAA Aviation Weather Center](https://tgftp.nws.noaa.gov/data/observations/metar/stations)
 
 ---
 
@@ -72,3 +73,5 @@ Learn about all the features and parameters with the PowerShell `Get-Help` comma
 ```powershell
 Get-Help .\lofiatc.ps1 -Full
 ```
+
+The script retrieves METAR reports from the [NOAA Aviation Weather Center](https://tgftp.nws.noaa.gov/data/observations/metar/stations).


### PR DESCRIPTION
## Summary
- fetch METAR via NOAA instead of scraping metar-taf.com
- drop unsupported sunrise/sunset and local time features
- show relative last update time using NOAA timestamp
- document NOAA METAR data requirement in README

## Testing
- `pwsh` command failed: `command not found`

------
https://chatgpt.com/codex/tasks/task_e_685dc093e5488324b2d86625e8174435