### PR TITLE
Add Pester tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,3 +72,9 @@ Learn about all the features and parameters with the PowerShell `Get-Help` comma
 ```powershell
 Get-Help .\lofiatc.ps1 -Full
 ```
+
+## **Run the Tests**
+Pester tests are located in the `tests` folder. Execute them with:
+```powershell
+Invoke-Pester
+```

--- a/tests/lofiatc.tests.ps1
+++ b/tests/lofiatc.tests.ps1
@@ -1,0 +1,43 @@
+# Import functions from the script without running the bottom execution block
+$scriptPath = Join-Path $PSScriptRoot '..' 'lofiatc.ps1'
+$scriptContent = Get-Content $scriptPath -Raw
+$funcContent = $scriptContent -split '# Determine the player to use',2
+Invoke-Expression $funcContent[0]
+
+Describe 'Get-METAR-TAF and ConvertFrom-METAR' {
+    $sampleHtml = '<html><head><meta name="description" content="KJFK 121651Z 18015G25KT 10SM BKN015 OVC030 22/18 A2992. Additional text"></head></html>'
+    Mock Invoke-WebRequest { [pscustomobject]@{ Content = $sampleHtml } }
+    $metar = Get-METAR-TAF -ICAO 'KJFK'
+    It 'returns raw METAR' { $metar | Should -Be 'KJFK 121651Z 18015G25KT 10SM BKN015 OVC030 22/18 A2992' }
+    $decoded = ConvertFrom-METAR -metar $metar
+    It 'decodes wind' { $decoded.Wind | Should -Be '180\u00B0 at 15 knots, gusting to 25 knots' }
+    It 'decodes visibility' { $decoded.Visibility | Should -Be '16.093 km' }
+    It 'decodes ceiling' { $decoded.Ceiling | Should -Be 'Broken at 1500 ft' }
+    It 'decodes temperature' { $decoded.Temperature | Should -Be '22\u00B0C' }
+    It 'decodes dewpoint' { $decoded.DewPoint | Should -Be '18\u00B0C' }
+    It 'decodes pressure' { $decoded.Pressure | Should -Be '1013.2 hPa' }
+}
+
+Describe 'Selection functions' {
+    Context 'Select-Item' {
+        Mock Read-Host { '2' }
+        It 'returns the chosen item' {
+            Select-Item -prompt 'Choose' -items @('A','B','C') | Should -Be 'B'
+        }
+    }
+
+    Context 'Select-ATCStream' {
+        $atcSources = @(
+            [pscustomobject]@{ Continent='North America'; Country='USA'; City='New York'; 'Airport Name'='JFK'; ICAO='KJFK'; IATA='JFK'; 'Channel Description'='Tower'; 'Stream URL'='towerUrl'; 'Webcam URL'='' },
+            [pscustomobject]@{ Continent='North America'; Country='USA'; City='New York'; 'Airport Name'='JFK'; ICAO='KJFK'; IATA='JFK'; 'Channel Description'='Ground'; 'Stream URL'='groundUrl'; 'Webcam URL'='http://cam' }
+        )
+        Mock Select-Item {
+            param($prompt,$items)
+            if ($prompt -like 'Select an airport*') { return $items[0] }
+            else { return $items[1] }
+        }
+        $result = Select-ATCStream -atcSources $atcSources -continent 'North America' -country 'USA'
+        It 'returns correct stream URL' { $result.StreamUrl | Should -Be 'groundUrl' }
+        It 'returns correct webcam URL' { $result.WebcamUrl | Should -Be 'http://cam' }
+    }
+}


### PR DESCRIPTION
## Summary
- add Pester tests for METAR parsing and selection helper functions
- document how to run the tests

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Output Detailed"` *(fails: command not found)*
- `powershell -NoLogo -NoProfile -Command "Invoke-Pester -Output Detailed"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685dc0abdf648324beec2ad7b334d3ed