### PR TITLE
Add custom Lofi source option

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,17 @@ Two parameters control the audio level of each stream:
 
 - `-ATCVolume` sets the ATC stream volume (default `65`).
 - `-LofiVolume` sets the Lofi Girl volume (default `50`).
+- `-LofiSource` lets you specify a custom Lofi audio or video URL or file path.
+  When omitted, the script uses the default Lofi Girl YouTube stream.
+
+Examples:
+```powershell
+# Stream from a remote URL
+./lofiatc.ps1 -LofiSource "https://example.com/lofi.mp3"
+
+# Use a local audio file
+./lofiatc.ps1 -LofiSource "C:\Music\my_lofi_mix.mp3"
+```
 
 ## **Update ATC Source List**
 Fetch the latest ATC stream information from LiveATC and merge it with the existing list.  The script also sorts the CSV for easier browsing:

--- a/lofiatc.ps1
+++ b/lofiatc.ps1
@@ -32,6 +32,10 @@ Volume level for the ATC stream. Default is 65.
 .PARAMETER LofiVolume
 Volume level for the Lofi Girl stream. Default is 50.
 
+.PARAMETER LofiSource
+URL or file path for the Lofi audio or video stream. Defaults to the official
+Lofi Girl YouTube feed.
+
 .NOTES
 File Name      : lofiatc.ps1
 Author         : github.com/RoMinjun
@@ -56,6 +60,10 @@ This command runs the script, includes webcam video if available, uses fzf for s
 .\lofiatc.ps1 -IncludeWebcamIfAvailable -UseFZF -Player VLC
 This command runs the script, includes webcam video if available, uses fzf for selecting ATC streams, and uses VLC as the media player.
 
+.EXAMPLE
+.\lofiatc.ps1 -LofiSource "C:\\Music\\my_lofi_mix.mp3"
+This command plays a local audio file instead of the default Lofi Girl stream.
+
 #>
 
 [CmdletBinding()]
@@ -69,7 +77,8 @@ param (
     [ValidateSet("VLC", "MPV", "Potplayer", "MPC-HC")]
     [string]$Player,
     [int]$ATCVolume = 65,
-    [int]$LofiVolume = 50
+    [int]$LofiVolume = 50,
+    [string]$LofiSource = "https://www.youtube.com/watch?v=jfKfPfyJRdk"
 )
 
 # MP4 == Default app for all files
@@ -777,7 +786,7 @@ if (-not $UseBaseCSV -and (Test-Path $liveCsv)) {
 }
 
 
-$lofiMusicUrl = "https://www.youtube.com/watch?v=jfKfPfyJRdk"
+$lofiMusicUrl = $LofiSource
 $atcSources = Import-ATCSources -csvPath $csvPath
 
 if ($RandomATC) {


### PR DESCRIPTION
## Summary
- allow specifying a Lofi audio/video source via `-LofiSource`
- document the option and add example usages for URLs and local files

## Testing
- `pwsh -NoProfile -Command "Get-Help ./lofiatc.ps1 -Full > /tmp/help.txt"`
- `pwsh -NoProfile ./lofiatc.ps1 -NoLofiMusic -RandomATC -LofiSource https://example.com/test.mp3 | head` *(fails: VLC is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6874f822bf788324b892f6c85047b105