### PR TITLE
Add Discord Rich Presence option

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,5 +101,8 @@ Pass `-OpenRadar` to automatically launch the selected airport's radar page in y
 ### Cross-Platform Player Detection
 When no `-Player` is specified the script now tries to locate `mpv` or `vlc` on macOS/Linux before falling back to Windows defaults.
 
+### Discord Rich Presence
+Use the `-DiscordRPC` switch to show what you're listening to in Discord. This requires the `discordrpc` module which can be installed via `Install-Module discordrpc -Scope CurrentUser`.
+
 # Help liveatc.net's existence
 This repo wouldn't be anything without [liveatc.net](https://www.liveatc.net). If you live near an airport and have a passion for air traffic control, and if it's legal in your country, consider [contacting LiveATC.net](https://www.liveatc.net/ct/contact.php). They can help you get set up with the necessary equipment.


### PR DESCRIPTION
## Summary
- document Discord integration via `-DiscordRPC`
- add `-DiscordRPC` param to the script
- add example for using Discord Rich Presence
- implement `Start-DiscordPresence` helper
- start Discord presence when requested

## Testing
- `pwsh -NoLogo -Command "Get-Command -Name ./lofiatc.ps1"`

------
https://chatgpt.com/codex/tasks/task_e_688a8875b9248324be444d2f67e916db