### PR TITLE
Add named configuration profiles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -365,6 +365,7 @@ Do not add a dependency solely to avoid writing a small amount of straightforwar
 
 Keep changes easy to review.
 
+- Before starting work on a GitHub issue, create a new dedicated branch from the requested base branch (or the repository default when none is specified) and link it to the issue, preferably with `gh issue develop`. If the issue is in the project board's `Ready` status, move it to `In progress` when work begins.
 - One logical change per branch/PR.
 - Avoid unrelated cleanup.
 - Do not rewrite large CSVs unless the task requires data changes.

--- a/README.md
+++ b/README.md
@@ -237,6 +237,14 @@ lofiatc -UseFZF -OpenRadar -ATCVolume 70 -LofiVolume 45
 # Load your last-used settings, but override to open radar this time
 lofiatc -LoadConfig -OpenRadar
 
+# Save and reuse a named setup; explicit values still override the profile
+lofiatc -SaveProfile Work -ShowMap -KeepOpen -ATCVolume 70
+lofiatc -Profile Work -ATCVolume 80
+
+# List or remove named profiles without starting playback
+lofiatc -ListProfiles
+lofiatc -RemoveProfile Work
+
 # Force a specific player
 lofiatc -Player mpv
 lofiatc -Player vlc
@@ -306,6 +314,10 @@ Get-Help lofiatc -Full
 | `-SaveConfig`   | switch    | false   | Saves the current flags/values to your user `config.json`. |
 | `-LoadConfig`   | switch    | false   | Loads options from your user `config.json`. CLI flags override loaded values. |
 | `-ConfigPath`   | string    | user data path | Custom path for saving/loading. |
+| `-Profile`      | string    | none    | Loads a named profile from the user data directory. CLI flags override profile values. |
+| `-SaveProfile`  | string    | none    | Saves the current flags/values as a named profile. |
+| `-ListProfiles` | switch    | false   | Lists saved profiles and exits without starting playback. |
+| `-RemoveProfile` | string   | none    | Removes a named profile and exits without starting playback. |
 | `-UseBaseCSV`   | switch    | false   | Force using the base `atc_sources.csv` even if a local updated file exists. |
 | `-ICAO`         | string    | none    | Select a specific airport by ICAO code. If multiple channels exist, you’ll be prompted unless `-RandomATC` is used. |
 | `-Nearby`       | switch    | false   | Uses your current location to show or select nearby airports. |
@@ -352,7 +364,25 @@ Even if your config has `OpenRadar: false`, you can re-enable it with:
 lofiatc -LoadConfig -OpenRadar
 ```
 
-By default, installed runs store `config.json` and `favorites.json` in your user data folder:
+### Named profiles
+
+Named profiles let you keep several reusable setups while preserving the existing `config.json` behavior. Profile names are 1–64 letters, numbers, underscores, or hyphens and must start with a letter or number.
+
+```powershell
+# Create or replace a profile, then continue with the selected session
+lofiatc -SaveProfile Work -ShowMap -KeepOpen -ATCVolume 70 -LofiVolume 45
+
+# Load it; the explicit volume wins over the saved value
+lofiatc -Profile Work -ATCVolume 80
+
+# Manage profiles without launching players or a browser
+lofiatc -ListProfiles
+lofiatc -RemoveProfile Work
+```
+
+The installed PowerShell command completes saved names for `-Profile`, `-SaveProfile`, and `-RemoveProfile`. Named profiles are written through a validated temporary file before replacement and are stored in the `profiles` subdirectory of the user data folder.
+
+By default, installed runs store `config.json`, `favorites.json`, and named profiles in your user data folder:
 - Windows: `$env:APPDATA\lofiatc`
 - macOS/Linux: `$XDG_CONFIG_HOME/lofiatc` or `~/.config/lofiatc`
 

--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ lofiatc -UseFZF -OpenRadar -ATCVolume 70 -LofiVolume 45
 lofiatc -LoadConfig -OpenRadar
 
 # Save and reuse a named setup; explicit values still override the profile
-lofiatc -SaveProfile Work -ShowMap -KeepOpen -ATCVolume 70
+lofiatc -SaveProfile Work -ATCVolume 70
 lofiatc -Profile Work -ATCVolume 80
 
 # List or remove named profiles without starting playback
@@ -315,7 +315,7 @@ Get-Help lofiatc -Full
 | `-LoadConfig`   | switch    | false   | Loads options from your user `config.json`. CLI flags override loaded values. |
 | `-ConfigPath`   | string    | user data path | Custom path for saving/loading. |
 | `-Profile`      | string    | none    | Loads a named profile from the user data directory. CLI flags override profile values. |
-| `-SaveProfile`  | string    | none    | Saves the current flags/values as a named profile. |
+| `-SaveProfile`  | string    | none    | Saves the current flags/values and selected ATC channel as a named profile. |
 | `-ListProfiles` | switch    | false   | Lists saved profiles and exits without starting playback. |
 | `-RemoveProfile` | string   | none    | Removes a named profile and exits without starting playback. |
 | `-UseBaseCSV`   | switch    | false   | Force using the base `atc_sources.csv` even if a local updated file exists. |
@@ -369,8 +369,8 @@ lofiatc -LoadConfig -OpenRadar
 Named profiles let you keep several reusable setups while preserving the existing `config.json` behavior. Profile names are 1–64 letters, numbers, underscores, or hyphens and must start with a letter or number.
 
 ```powershell
-# Create or replace a profile, then continue with the selected session
-lofiatc -SaveProfile Work -ShowMap -KeepOpen -ATCVolume 70 -LofiVolume 45
+# Create or replace a profile, then choose the channel to remember
+lofiatc -SaveProfile Work -ATCVolume 70 -LofiVolume 45
 
 # Load it; the explicit volume wins over the saved value
 lofiatc -Profile Work -ATCVolume 80
@@ -379,6 +379,8 @@ lofiatc -Profile Work -ATCVolume 80
 lofiatc -ListProfiles
 lofiatc -RemoveProfile Work
 ```
+
+The selected ATC channel is saved with the profile, so `-Profile Work` can start that feed without asking for a channel again. If the saved feed is no longer available, LofiATC warns and falls back to the normal selection flow. Explicit selection modes such as `-RandomATC`, `-Nearby`, `-ShowMap`, and `-UseFavorite` take precedence over the saved channel.
 
 The installed PowerShell command completes saved names for `-Profile`, `-SaveProfile`, and `-RemoveProfile`. Named profiles are written through a validated temporary file before replacement and are stored in the `profiles` subdirectory of the user data folder.
 

--- a/lofiatc.ps1
+++ b/lofiatc.ps1
@@ -69,7 +69,7 @@ Optional path for the saved configuration file. Defaults to user data when insta
 Load a named profile from the user data directory. Explicit command-line values take precedence.
 
 .PARAMETER SaveProfile
-Save the current options as a named profile in the user data directory.
+Save the current options and selected ATC channel as a named profile in the user data directory.
 
 .PARAMETER ListProfiles
 List saved named profiles and exit without starting playback.
@@ -208,8 +208,9 @@ try {
         Import-LofiATCConfig -ConfigPath $ConfigPath -BoundParameters $PSBoundParameters
     }
 
+    $profileChannel = $null
     if ($Profile) {
-        Import-LofiATCProfile -Name $Profile -BoundParameters $PSBoundParameters
+        $profileChannel = Import-LofiATCProfile -Name $Profile -BoundParameters $PSBoundParameters
     }
 
     if ($ICAO) {
@@ -255,7 +256,7 @@ try {
         Export-LofiATCConfig -CommandPath $MyInvocation.MyCommand.Path -ConfigPath $ConfigPath
     }
 
-    if ($SaveProfile) {
+    if ($SaveProfile -and $ShowMap -and $KeepOpen) {
         Export-LofiATCProfile -Name $SaveProfile -CommandPath $MyInvocation.MyCommand.Path
     }
 
@@ -297,6 +298,7 @@ try {
         -ATCVolume $ATCVolume `
         -LofiVolume $LofiVolume `
         -LofiMusicUrl $lofiMusicUrl `
+        -ProfileChannel $profileChannel `
         -Nearby:$Nearby `
         -ShowMap:$ShowMap `
         -KeepOpen:$KeepOpen `
@@ -309,6 +311,13 @@ try {
         -NoLofiMusic:$NoLofiMusic `
         -PlayLofiGirlVideo:$PlayLofiGirlVideo `
         -ShowLofiTrack:$ShowLofiTrack
+
+    if ($SaveProfile) {
+        Export-LofiATCProfile `
+            -Name $SaveProfile `
+            -CommandPath $MyInvocation.MyCommand.Path `
+            -SelectedATC $selection.SelectedATC
+    }
 
     Start-LofiATCSession `
         -SelectedATC $selection.SelectedATC `

--- a/lofiatc.ps1
+++ b/lofiatc.ps1
@@ -59,8 +59,23 @@ Open the FlightAware radar page for the selected ICAO after displaying the welco
 .PARAMETER SaveConfig
 Save the parameters used for the current run to a configuration file.
 
+.PARAMETER LoadConfig
+Load options from the default or custom configuration file. Explicit command-line values take precedence.
+
 .PARAMETER ConfigPath
 Optional path for the saved configuration file. Defaults to user data when installed, with repo-local config as a compatibility fallback.
+
+.PARAMETER Profile
+Load a named profile from the user data directory. Explicit command-line values take precedence.
+
+.PARAMETER SaveProfile
+Save the current options as a named profile in the user data directory.
+
+.PARAMETER ListProfiles
+List saved named profiles and exit without starting playback.
+
+.PARAMETER RemoveProfile
+Remove a named profile and exit without starting playback.
 
 .PARAMETER Nearby
 Shows a list of nearby airports to your current device location (IP as fallback)
@@ -108,6 +123,13 @@ param (
     [switch]$LoadConfig,
     [switch]$SaveConfig,
     [string]$ConfigPath,
+    [ValidatePattern('^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$')]
+    [string]$Profile,
+    [ValidatePattern('^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$')]
+    [string]$SaveProfile,
+    [switch]$ListProfiles,
+    [ValidatePattern('^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$')]
+    [string]$RemoveProfile,
     [switch]$OpenRadar,
     [switch]$Nearby,
     [ValidateRange(1,5000)]
@@ -150,10 +172,44 @@ try {
     # set reference point for relative paths
     $scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 
+    if ($ListProfiles -and $RemoveProfile) {
+        throw '-ListProfiles and -RemoveProfile cannot be used together.'
+    }
+
+    if (($ListProfiles -or $RemoveProfile) -and ($Profile -or $SaveProfile -or $LoadConfig -or $SaveConfig)) {
+        throw '-ListProfiles and -RemoveProfile cannot be combined with profile or configuration load/save operations.'
+    }
+
+    if ($Profile -and $LoadConfig) {
+        throw '-Profile and -LoadConfig cannot be used together.'
+    }
+
+    if ($SaveProfile -and $SaveConfig) {
+        throw '-SaveProfile and -SaveConfig cannot be used together.'
+    }
+
+    if ($ConfigPath -and ($Profile -or $SaveProfile -or $ListProfiles -or $RemoveProfile)) {
+        throw '-ConfigPath applies only to -LoadConfig and -SaveConfig, not named profiles.'
+    }
+
+    if ($ListProfiles) {
+        Get-LofiATCProfile
+        return
+    }
+
+    if ($RemoveProfile) {
+        Remove-LofiATCProfile -Name $RemoveProfile
+        return
+    }
+
     # Load config if specified, then override with any directly provided parameters
     if ($LoadConfig) {
         if (-not $ConfigPath) { $ConfigPath = Resolve-LofiATCUserFilePath -FileName 'config.json' -ScriptDir $scriptDir }
         Import-LofiATCConfig -ConfigPath $ConfigPath -BoundParameters $PSBoundParameters
+    }
+
+    if ($Profile) {
+        Import-LofiATCProfile -Name $Profile -BoundParameters $PSBoundParameters
     }
 
     if ($ICAO) {
@@ -197,6 +253,10 @@ try {
     if ($SaveConfig) {
         if (-not $ConfigPath) { $ConfigPath = Join-Path (Initialize-LofiATCUserDataPath) 'config.json' }
         Export-LofiATCConfig -CommandPath $MyInvocation.MyCommand.Path -ConfigPath $ConfigPath
+    }
+
+    if ($SaveProfile) {
+        Export-LofiATCProfile -Name $SaveProfile -CommandPath $MyInvocation.MyCommand.Path
     }
 
     # Test the selected player

--- a/modules/LofiATC.Core.psm1
+++ b/modules/LofiATC.Core.psm1
@@ -103,7 +103,11 @@ Function Get-LofiATCIgnoredConfigParameterNames {
         'PipelineVariable',
         'SaveConfig',
         'LoadConfig',
-        'ConfigPath'
+        'ConfigPath',
+        'Profile',
+        'SaveProfile',
+        'ListProfiles',
+        'RemoveProfile'
     )
 }
 
@@ -153,10 +157,100 @@ Function Initialize-LofiATCUserDataPath {
     return $userDataDir
 }
 
+Function Test-LofiATCProfileName {
+    param(
+        [string]$Name
+    )
+
+    return (-not [string]::IsNullOrWhiteSpace($Name) -and $Name -match '^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$')
+}
+
+Function Get-LofiATCProfilesPath {
+    param(
+        [switch]$Create
+    )
+
+    $profilesPath = Join-Path (Get-LofiATCUserDataPath) 'profiles'
+    if ($Create -and -not (Test-Path -LiteralPath $profilesPath)) {
+        New-Item -ItemType Directory -Path $profilesPath -Force | Out-Null
+    }
+
+    return $profilesPath
+}
+
+Function Resolve-LofiATCProfilePath {
+    param(
+        [string]$Name,
+        [switch]$CreateDirectory
+    )
+
+    if (-not (Test-LofiATCProfileName -Name $Name)) {
+        throw "Profile name '$Name' is invalid. Use 1-64 letters, numbers, underscores, or hyphens, starting with a letter or number."
+    }
+
+    $profilesPath = Get-LofiATCProfilesPath -Create:$CreateDirectory
+    return (Join-Path $profilesPath ($Name + '.json'))
+}
+
+Function Get-LofiATCProfile {
+    $profilesPath = Get-LofiATCProfilesPath
+    if (-not (Test-Path -LiteralPath $profilesPath)) {
+        return
+    }
+
+    Get-ChildItem -LiteralPath $profilesPath -Filter '*.json' -File |
+        Where-Object { Test-LofiATCProfileName -Name $_.BaseName } |
+        Sort-Object -Property BaseName |
+        ForEach-Object {
+            [pscustomobject]@{
+                Name          = $_.BaseName
+                Path          = $_.FullName
+                LastWriteTime = $_.LastWriteTime
+            }
+        }
+}
+
+Function Write-LofiATCJsonFileAtomically {
+    param(
+        [object]$InputObject,
+        [string]$Path
+    )
+
+    $directory = Split-Path -Parent $Path
+    if ($directory -and -not (Test-Path -LiteralPath $directory)) {
+        New-Item -ItemType Directory -Path $directory -Force | Out-Null
+    }
+
+    $fileName = Split-Path -Leaf $Path
+    $temporaryPath = Join-Path $directory ('.{0}.{1}.tmp' -f $fileName, [guid]::NewGuid().ToString('N'))
+
+    try {
+        $json = $InputObject | ConvertTo-Json
+        $utf8WithoutBom = New-Object System.Text.UTF8Encoding($false)
+        [System.IO.File]::WriteAllText($temporaryPath, $json, $utf8WithoutBom)
+
+        # Validate the complete temporary file before it can replace user data.
+        $null = Get-Content -LiteralPath $temporaryPath -Raw | ConvertFrom-Json
+
+        if (Test-Path -LiteralPath $Path) {
+            [System.IO.File]::Replace($temporaryPath, $Path, $null)
+        }
+        else {
+            [System.IO.File]::Move($temporaryPath, $Path)
+        }
+    }
+    finally {
+        if (Test-Path -LiteralPath $temporaryPath) {
+            Remove-Item -LiteralPath $temporaryPath -Force
+        }
+    }
+}
+
 Function Import-LofiATCConfig {
     param(
         [string]$ConfigPath,
-        [hashtable]$BoundParameters
+        [hashtable]$BoundParameters,
+        [int]$VariableScope = 1
     )
 
     if (-not (Test-Path $ConfigPath)) {
@@ -174,7 +268,7 @@ Function Import-LofiATCConfig {
         }
 
         if (-not $BoundParameters.ContainsKey($name) -and $null -ne $prop.Value -and $prop.Value -ne "") {
-            Set-Variable -Name $name -Value $prop.Value -Scope 1
+            Set-Variable -Name $name -Value $prop.Value -Scope $VariableScope
         }
     }
 
@@ -184,7 +278,9 @@ Function Import-LofiATCConfig {
 Function Export-LofiATCConfig {
     param(
         [string]$CommandPath,
-        [string]$ConfigPath
+        [string]$ConfigPath,
+        [switch]$Atomic,
+        [int]$VariableScope = 1
     )
 
     $ignoredParameters = Get-LofiATCIgnoredConfigParameterNames
@@ -196,7 +292,7 @@ Function Export-LofiATCConfig {
             continue
         }
 
-        $value = Get-Variable -Name $name -ValueOnly -Scope 1
+        $value = Get-Variable -Name $name -ValueOnly -Scope $VariableScope
         if ($value -is [System.Management.Automation.SwitchParameter]) {
             $value = [bool]$value
         }
@@ -211,8 +307,51 @@ Function Export-LofiATCConfig {
         New-Item -ItemType Directory -Path $configDir -Force | Out-Null
     }
 
-    $config | ConvertTo-Json | Set-Content -Path $ConfigPath
+    if ($Atomic) {
+        Write-LofiATCJsonFileAtomically -InputObject $config -Path $ConfigPath
+    }
+    else {
+        $config | ConvertTo-Json | Set-Content -Path $ConfigPath
+    }
     Write-Information "Saved config to $ConfigPath"
+}
+
+Function Import-LofiATCProfile {
+    param(
+        [string]$Name,
+        [hashtable]$BoundParameters
+    )
+
+    $profilePath = Resolve-LofiATCProfilePath -Name $Name
+    if (-not (Test-Path -LiteralPath $profilePath)) {
+        throw "Profile '$Name' was not found. Use -ListProfiles to view saved profiles."
+    }
+
+    Import-LofiATCConfig -ConfigPath $profilePath -BoundParameters $BoundParameters -VariableScope 2
+}
+
+Function Export-LofiATCProfile {
+    param(
+        [string]$Name,
+        [string]$CommandPath
+    )
+
+    $profilePath = Resolve-LofiATCProfilePath -Name $Name -CreateDirectory
+    Export-LofiATCConfig -CommandPath $CommandPath -ConfigPath $profilePath -Atomic -VariableScope 2
+}
+
+Function Remove-LofiATCProfile {
+    param(
+        [string]$Name
+    )
+
+    $profilePath = Resolve-LofiATCProfilePath -Name $Name
+    if (-not (Test-Path -LiteralPath $profilePath)) {
+        throw "Profile '$Name' was not found. Use -ListProfiles to view saved profiles."
+    }
+
+    Remove-Item -LiteralPath $profilePath -Force
+    Write-Information "Removed profile '$Name' from $profilePath"
 }
 
 Function Test-ConsoleKeyAvailable {

--- a/modules/LofiATC.Core.psm1
+++ b/modules/LofiATC.Core.psm1
@@ -223,6 +223,7 @@ Function Write-LofiATCJsonFileAtomically {
 
     $fileName = Split-Path -Leaf $Path
     $temporaryPath = Join-Path $directory ('.{0}.{1}.tmp' -f $fileName, [guid]::NewGuid().ToString('N'))
+    $backupPath = $Path + '.bak'
 
     try {
         $json = $InputObject | ConvertTo-Json
@@ -233,7 +234,11 @@ Function Write-LofiATCJsonFileAtomically {
         $null = Get-Content -LiteralPath $temporaryPath -Raw | ConvertFrom-Json
 
         if (Test-Path -LiteralPath $Path) {
-            [System.IO.File]::Replace($temporaryPath, $Path, $null)
+            if (Test-Path -LiteralPath $backupPath) {
+                Remove-Item -LiteralPath $backupPath -Force
+            }
+
+            [System.IO.File]::Replace($temporaryPath, $Path, $backupPath)
         }
         else {
             [System.IO.File]::Move($temporaryPath, $Path)

--- a/modules/LofiATC.Core.psm1
+++ b/modules/LofiATC.Core.psm1
@@ -107,7 +107,8 @@ Function Get-LofiATCIgnoredConfigParameterNames {
         'Profile',
         'SaveProfile',
         'ListProfiles',
-        'RemoveProfile'
+        'RemoveProfile',
+        'SelectedChannel'
     )
 }
 
@@ -285,7 +286,8 @@ Function Export-LofiATCConfig {
         [string]$CommandPath,
         [string]$ConfigPath,
         [switch]$Atomic,
-        [int]$VariableScope = 1
+        [int]$VariableScope = 1,
+        [hashtable]$AdditionalValues
     )
 
     $ignoredParameters = Get-LofiATCIgnoredConfigParameterNames
@@ -304,6 +306,12 @@ Function Export-LofiATCConfig {
 
         if ($null -ne $value -and $value -ne "") {
             $config[$name] = $value
+        }
+    }
+
+    if ($AdditionalValues) {
+        foreach ($name in $AdditionalValues.Keys) {
+            $config[$name] = $AdditionalValues[$name]
         }
     }
 
@@ -333,16 +341,87 @@ Function Import-LofiATCProfile {
     }
 
     Import-LofiATCConfig -ConfigPath $profilePath -BoundParameters $BoundParameters -VariableScope 2
+
+    $profile = Get-Content -LiteralPath $profilePath -Raw | ConvertFrom-Json
+    if ($profile.PSObject.Properties['SelectedChannel']) {
+        return $profile.SelectedChannel
+    }
+}
+
+Function Get-LofiATCProfileChannelData {
+    param(
+        [object]$SelectedATC
+    )
+
+    if (-not $SelectedATC -or -not $SelectedATC.AirportInfo) {
+        return $null
+    }
+
+    return [ordered]@{
+        ICAO               = [string]$SelectedATC.AirportInfo.ICAO
+        ChannelDescription = [string]$SelectedATC.AirportInfo.'Channel Description'
+        StreamUrl          = [string]$SelectedATC.AirportInfo.'Stream URL'
+    }
 }
 
 Function Export-LofiATCProfile {
     param(
         [string]$Name,
-        [string]$CommandPath
+        [string]$CommandPath,
+        [object]$SelectedATC
     )
 
     $profilePath = Resolve-LofiATCProfilePath -Name $Name -CreateDirectory
-    Export-LofiATCConfig -CommandPath $CommandPath -ConfigPath $profilePath -Atomic -VariableScope 2
+    $additionalValues = @{}
+    $selectedChannel = Get-LofiATCProfileChannelData -SelectedATC $SelectedATC
+    if ($selectedChannel) {
+        $additionalValues.SelectedChannel = $selectedChannel
+    }
+
+    Export-LofiATCConfig `
+        -CommandPath $CommandPath `
+        -ConfigPath $profilePath `
+        -Atomic `
+        -VariableScope 2 `
+        -AdditionalValues $additionalValues
+}
+
+Function Resolve-LofiATCProfileChannel {
+    param(
+        [array]$AtcSources,
+        [object]$SelectedChannel
+    )
+
+    if (-not $SelectedChannel -or
+        [string]::IsNullOrWhiteSpace([string]$SelectedChannel.ICAO) -or
+        [string]::IsNullOrWhiteSpace([string]$SelectedChannel.ChannelDescription)) {
+        return $null
+    }
+
+    $matches = @($AtcSources | Where-Object {
+        $_.ICAO -eq $SelectedChannel.ICAO -and
+        $_.'Channel Description' -eq $SelectedChannel.ChannelDescription
+    })
+
+    $match = $matches | Where-Object {
+        -not [string]::IsNullOrWhiteSpace([string]$SelectedChannel.StreamUrl) -and
+        $_.'Stream URL' -eq $SelectedChannel.StreamUrl
+    } | Select-Object -First 1
+
+    if (-not $match) {
+        $match = $matches | Select-Object -First 1
+    }
+
+    if (-not $match) {
+        Write-Warning "Saved channel '$($SelectedChannel.ICAO) - $($SelectedChannel.ChannelDescription)' is no longer available. Falling back to normal selection."
+        return $null
+    }
+
+    return @{
+        StreamUrl   = $match.'Stream URL'
+        WebcamUrl   = $match.'Webcam URL'
+        AirportInfo = $match
+    }
 }
 
 Function Remove-LofiATCProfile {
@@ -834,6 +913,7 @@ Function Resolve-SelectedATCStream {
         [int]$ATCVolume,
         [int]$LofiVolume,
         [string]$LofiMusicUrl,
+        [object]$ProfileChannel,
         [switch]$Nearby,
         [switch]$ShowMap,
         [switch]$KeepOpen,
@@ -935,7 +1015,18 @@ Function Resolve-SelectedATCStream {
 
     $selectedATC = $null
 
-    if ($ICAO) {
+    $profileChannelMatchesICAO = (
+        -not $ICAO -or
+        -not $ProfileChannel -or
+        [string]$ProfileChannel.ICAO -eq $ICAO
+    )
+    $profileSelectionOverridden = $Nearby -or $ShowMap -or $RandomATC -or $UseFavorite
+
+    if ($ProfileChannel -and $profileChannelMatchesICAO -and -not $profileSelectionOverridden) {
+        $selectedATC = Resolve-LofiATCProfileChannel -AtcSources $AtcSources -SelectedChannel $ProfileChannel
+    }
+
+    if (-not $selectedATC -and $ICAO) {
         $selectedATC = Select-ATCStreamByICAO `
             -AtcSources $AtcSources `
             -ICAO $ICAO `

--- a/packaging/LofiATC/LofiATC.psm1
+++ b/packaging/LofiATC/LofiATC.psm1
@@ -425,7 +425,7 @@ Uses OCR to show the current Lofi Girl track in persistent map mode.
 Loads a named configuration profile. Explicit command-line values take precedence.
 
 .PARAMETER SaveProfile
-Saves the current options as a named configuration profile.
+Saves the current options and selected ATC channel as a named configuration profile.
 
 .PARAMETER ListProfiles
 Lists saved named profiles without starting playback.

--- a/packaging/LofiATC/LofiATC.psm1
+++ b/packaging/LofiATC/LofiATC.psm1
@@ -420,6 +420,18 @@ Repository ref to use with -UpdateSources. Defaults to the ref recorded by the i
 
 .PARAMETER ShowLofiTrack
 Uses OCR to show the current Lofi Girl track in persistent map mode.
+
+.PARAMETER Profile
+Loads a named configuration profile. Explicit command-line values take precedence.
+
+.PARAMETER SaveProfile
+Saves the current options as a named configuration profile.
+
+.PARAMETER ListProfiles
+Lists saved named profiles without starting playback.
+
+.PARAMETER RemoveProfile
+Removes a named configuration profile without starting playback.
 #>
     [CmdletBinding()]
     param (
@@ -445,6 +457,13 @@ Uses OCR to show the current Lofi Girl track in persistent map mode.
         [switch]$LoadConfig,
         [switch]$SaveConfig,
         [string]$ConfigPath,
+        [ValidatePattern('^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$')]
+        [string]$Profile,
+        [ValidatePattern('^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$')]
+        [string]$SaveProfile,
+        [switch]$ListProfiles,
+        [ValidatePattern('^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$')]
+        [string]$RemoveProfile,
         [switch]$OpenRadar,
         [switch]$Nearby,
         [ValidateRange(1,5000)]
@@ -487,5 +506,44 @@ Uses OCR to show the current Lofi Girl track in persistent map mode.
 
     & $scriptPath @forwardedParameters
 }
+
+$profileNameCompleter = {
+    param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameters)
+
+    if ($env:LOFIATC_USER_DATA) {
+        $userDataPath = $env:LOFIATC_USER_DATA
+    }
+    elseif ($env:APPDATA) {
+        $userDataPath = Join-Path $env:APPDATA 'lofiatc'
+    }
+    elseif ($env:XDG_CONFIG_HOME) {
+        $userDataPath = Join-Path $env:XDG_CONFIG_HOME 'lofiatc'
+    }
+    else {
+        $userDataPath = Join-Path $HOME '.config/lofiatc'
+    }
+
+    $profilesPath = Join-Path $userDataPath 'profiles'
+    if (-not (Test-Path -LiteralPath $profilesPath)) {
+        return
+    }
+
+    Get-ChildItem -LiteralPath $profilesPath -Filter '*.json' -File |
+        Where-Object {
+            $_.BaseName -match '^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$' -and
+            $_.BaseName -like ($wordToComplete + '*')
+        } |
+        Sort-Object -Property BaseName |
+        ForEach-Object {
+            New-Object System.Management.Automation.CompletionResult(
+                $_.BaseName,
+                $_.BaseName,
+                [System.Management.Automation.CompletionResultType]::ParameterValue,
+                "Saved LofiATC profile '$($_.BaseName)'"
+            )
+        }
+}
+
+Register-ArgumentCompleter -CommandName lofiatc -ParameterName Profile, SaveProfile, RemoveProfile -ScriptBlock $profileNameCompleter
 
 Export-ModuleMember -Function lofiatc, Update-LofiATC, Update-LofiATCSources, Get-LofiATCVersion

--- a/packaging/LofiATC/LofiATC.psm1
+++ b/packaging/LofiATC/LofiATC.psm1
@@ -544,6 +544,8 @@ $profileNameCompleter = {
         }
 }
 
-Register-ArgumentCompleter -CommandName lofiatc -ParameterName Profile, SaveProfile, RemoveProfile -ScriptBlock $profileNameCompleter
+foreach ($profileParameterName in @('Profile', 'SaveProfile', 'RemoveProfile')) {
+    Register-ArgumentCompleter -CommandName lofiatc -ParameterName $profileParameterName -ScriptBlock $profileNameCompleter
+}
 
 Export-ModuleMember -Function lofiatc, Update-LofiATC, Update-LofiATCSources, Get-LofiATCVersion

--- a/tests/LofiATC.Module.Tests.ps1
+++ b/tests/LofiATC.Module.Tests.ps1
@@ -12,6 +12,42 @@ Describe 'LofiATC module updater' {
         Remove-Module LofiATC -Force -ErrorAction SilentlyContinue
     }
 
+    It 'exposes and validates named profile parameters on the installed command' {
+        $parameters = (Get-Command lofiatc).Parameters
+
+        $parameters.Keys | Should -Contain 'Profile'
+        $parameters.Keys | Should -Contain 'SaveProfile'
+        $parameters.Keys | Should -Contain 'ListProfiles'
+        $parameters.Keys | Should -Contain 'RemoveProfile'
+
+        $profilePattern = @($parameters.Profile.Attributes | Where-Object { $_ -is [System.Management.Automation.ValidatePatternAttribute] })[0]
+        $profilePattern.RegexPattern | Should -Be '^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$'
+    }
+
+    It 'completes saved profile names' {
+        $previousUserDataPath = $env:LOFIATC_USER_DATA
+        $env:LOFIATC_USER_DATA = Join-Path $TestDrive 'completion-user-data'
+        $profilesPath = Join-Path $env:LOFIATC_USER_DATA 'profiles'
+        New-Item -ItemType Directory -Path $profilesPath -Force | Out-Null
+        '{}' | Set-Content -Path (Join-Path $profilesPath 'Work.json') -Encoding UTF8
+        '{}' | Set-Content -Path (Join-Path $profilesPath 'Home.json') -Encoding UTF8
+
+        try {
+            $inputScript = 'lofiatc -Profile Wo'
+            $completion = TabExpansion2 $inputScript $inputScript.Length
+            @($completion.CompletionMatches.CompletionText) | Should -Contain 'Work'
+            @($completion.CompletionMatches.CompletionText) | Should -Not -Contain 'Home'
+        }
+        finally {
+            if ($null -eq $previousUserDataPath) {
+                Remove-Item Env:\LOFIATC_USER_DATA -ErrorAction SilentlyContinue
+            }
+            else {
+                $env:LOFIATC_USER_DATA = $previousUserDataPath
+            }
+        }
+    }
+
     It 'runs the downloaded installer without mutating the PowerShell profile' {
         $installRoot = Join-Path $TestDrive 'lofiatc'
         New-Item -ItemType Directory -Path $installRoot -Force | Out-Null

--- a/tests/lofiatc.Tests.ps1
+++ b/tests/lofiatc.Tests.ps1
@@ -449,7 +449,12 @@ level	page_num	block_num	par_num	line_num	word_num	left	top	width	height	conf	te
   "Player": "VLC",
   "OpenRadar": true,
   "ATCVolume": 70,
-  "LofiVolume": 45
+  "LofiVolume": 45,
+  "SelectedChannel": {
+    "ICAO": "EHAM",
+    "ChannelDescription": "EHAM Tower",
+    "StreamUrl": "https://example.com/eham-twr"
+  }
 }
 '@ | Set-Content -Path (Join-Path $profilesPath 'Work.json') -Encoding UTF8
 
@@ -459,12 +464,114 @@ level	page_num	block_num	par_num	line_num	word_num	left	top	width	height	conf	te
             $LofiVolume = 50
             $boundParameters = @{ Player = $true }
 
-            Import-LofiATCProfile -Name 'Work' -BoundParameters $boundParameters
+            $profileChannel = Import-LofiATCProfile -Name 'Work' -BoundParameters $boundParameters
 
             $Player | Should -Be 'MPV'
             $OpenRadar | Should -BeTrue
             $ATCVolume | Should -Be 70
             $LofiVolume | Should -Be 45
+            $profileChannel.ICAO | Should -Be 'EHAM'
+            $profileChannel.ChannelDescription | Should -Be 'EHAM Tower'
+        }
+
+        It 'saves the selected ATC channel in the profile' {
+            $commandPath = Join-Path $TestDrive 'profile-command.ps1'
+            'param([string]$Player)' | Set-Content -LiteralPath $commandPath -Encoding UTF8
+            $Player = 'MPV'
+            $selectedATC = @{
+                AirportInfo = [pscustomobject]@{
+                    ICAO                  = 'EHAM'
+                    'Channel Description' = 'EHAM Tower'
+                    'Stream URL'          = 'https://example.com/eham-twr'
+                }
+            }
+
+            Export-LofiATCProfile `
+                -Name 'Work' `
+                -CommandPath $commandPath `
+                -SelectedATC $selectedATC `
+                -InformationAction SilentlyContinue
+
+            $profilePath = Resolve-LofiATCProfilePath -Name 'Work'
+            $profile = Get-Content -LiteralPath $profilePath -Raw | ConvertFrom-Json
+            $profile.Player | Should -Be 'MPV'
+            $profile.SelectedChannel.ICAO | Should -Be 'EHAM'
+            $profile.SelectedChannel.ChannelDescription | Should -Be 'EHAM Tower'
+            $profile.SelectedChannel.StreamUrl | Should -Be 'https://example.com/eham-twr'
+        }
+
+        It 'restores the saved channel without invoking channel selection' {
+            $sources = @(
+                [pscustomobject]@{
+                    ICAO                  = 'EHAM'
+                    'Channel Description' = 'EHAM Tower'
+                    'Stream URL'          = 'https://example.com/eham-twr'
+                    'Webcam URL'          = ''
+                },
+                [pscustomobject]@{
+                    ICAO                  = 'EHAM'
+                    'Channel Description' = 'EHAM Ground'
+                    'Stream URL'          = 'https://example.com/eham-gnd'
+                    'Webcam URL'          = ''
+                }
+            )
+            $savedChannel = [pscustomobject]@{
+                ICAO               = 'EHAM'
+                ChannelDescription = 'EHAM Tower'
+                StreamUrl          = 'https://example.com/eham-twr'
+            }
+            Mock Select-ATCStreamByICAO { throw 'Interactive channel selection should not run.' }
+
+            $selection = Resolve-SelectedATCStream `
+                -AtcSources $sources `
+                -ProfileChannel $savedChannel
+
+            $selection.SelectedATC.AirportInfo.'Channel Description' | Should -Be 'EHAM Tower'
+            Should -Invoke Select-ATCStreamByICAO -Times 0 -Exactly
+        }
+
+        It 'matches a saved channel by description when its stream URL changes' {
+            $sources = @(
+                [pscustomobject]@{
+                    ICAO                  = 'EHAM'
+                    'Channel Description' = 'EHAM Tower'
+                    'Stream URL'          = 'https://example.com/new-eham-twr'
+                    'Webcam URL'          = ''
+                }
+            )
+            $savedChannel = [pscustomobject]@{
+                ICAO               = 'EHAM'
+                ChannelDescription = 'EHAM Tower'
+                StreamUrl          = 'https://example.com/old-eham-twr'
+            }
+
+            $selected = Resolve-LofiATCProfileChannel -AtcSources $sources -SelectedChannel $savedChannel
+
+            $selected.StreamUrl | Should -Be 'https://example.com/new-eham-twr'
+        }
+
+        It 'warns and returns to normal selection when the saved channel disappeared' {
+            $sources = @(
+                [pscustomobject]@{
+                    ICAO                  = 'EHAM'
+                    'Channel Description' = 'EHAM Ground'
+                    'Stream URL'          = 'https://example.com/eham-gnd'
+                    'Webcam URL'          = ''
+                }
+            )
+            $savedChannel = [pscustomobject]@{
+                ICAO               = 'EHAM'
+                ChannelDescription = 'EHAM Tower'
+                StreamUrl          = 'https://example.com/eham-twr'
+            }
+            Mock Write-Warning
+
+            $selected = Resolve-LofiATCProfileChannel -AtcSources $sources -SelectedChannel $savedChannel
+
+            $selected | Should -BeNullOrEmpty
+            Should -Invoke Write-Warning -Times 1 -Exactly -ParameterFilter {
+                $Message -match 'Saved channel.*EHAM Tower.*no longer available'
+            }
         }
 
         It 'writes valid JSON atomically and leaves no temporary files' {
@@ -517,6 +624,7 @@ level	page_num	block_num	par_num	line_num	word_num	left	top	width	height	conf	te
             $ignored | Should -Contain 'SaveProfile'
             $ignored | Should -Contain 'ListProfiles'
             $ignored | Should -Contain 'RemoveProfile'
+            $ignored | Should -Contain 'SelectedChannel'
         }
     }
 

--- a/tests/lofiatc.Tests.ps1
+++ b/tests/lofiatc.Tests.ps1
@@ -404,6 +404,121 @@ level	page_num	block_num	par_num	line_num	word_num	left	top	width	height	conf	te
         }
     }
 
+    Context 'Named configuration profiles' {
+        BeforeEach {
+            $script:previousUserDataPath = $env:LOFIATC_USER_DATA
+            $env:LOFIATC_USER_DATA = Join-Path $TestDrive 'user-data'
+        }
+
+        AfterEach {
+            if ($null -eq $script:previousUserDataPath) {
+                Remove-Item Env:\LOFIATC_USER_DATA -ErrorAction SilentlyContinue
+            }
+            else {
+                $env:LOFIATC_USER_DATA = $script:previousUserDataPath
+            }
+        }
+
+        It 'exposes named profile operations on the script entrypoint' {
+            $parameters = (Get-Command $scriptPath).Parameters
+
+            $parameters.Keys | Should -Contain 'Profile'
+            $parameters.Keys | Should -Contain 'SaveProfile'
+            $parameters.Keys | Should -Contain 'ListProfiles'
+            $parameters.Keys | Should -Contain 'RemoveProfile'
+        }
+
+        It 'resolves profile names beneath the user data directory' {
+            $profilePath = Resolve-LofiATCProfilePath -Name 'Work_2' -CreateDirectory
+            $expectedPath = Join-Path (Join-Path $env:LOFIATC_USER_DATA 'profiles') 'Work_2.json'
+
+            $profilePath | Should -Be $expectedPath
+            Test-Path -LiteralPath (Split-Path -Parent $profilePath) | Should -BeTrue
+        }
+
+        It 'rejects profile names that could escape the profile directory' {
+            { Resolve-LofiATCProfilePath -Name '../work' } | Should -Throw '*Profile name*invalid*'
+            { Resolve-LofiATCProfilePath -Name 'work/profile' } | Should -Throw '*Profile name*invalid*'
+            { Resolve-LofiATCProfilePath -Name '.hidden' } | Should -Throw '*Profile name*invalid*'
+        }
+
+        It 'loads profile values while preserving explicit command-line values' {
+            $profilesPath = Get-LofiATCProfilesPath -Create
+            @'
+{
+  "Player": "VLC",
+  "OpenRadar": true,
+  "ATCVolume": 70,
+  "LofiVolume": 45
+}
+'@ | Set-Content -Path (Join-Path $profilesPath 'Work.json') -Encoding UTF8
+
+            $Player = 'MPV'
+            $OpenRadar = $false
+            $ATCVolume = 65
+            $LofiVolume = 50
+            $boundParameters = @{ Player = $true }
+
+            Import-LofiATCProfile -Name 'Work' -BoundParameters $boundParameters
+
+            $Player | Should -Be 'MPV'
+            $OpenRadar | Should -BeTrue
+            $ATCVolume | Should -Be 70
+            $LofiVolume | Should -Be 45
+        }
+
+        It 'writes valid JSON atomically and leaves no temporary files' {
+            $profilePath = Resolve-LofiATCProfilePath -Name 'Work' -CreateDirectory
+
+            Write-LofiATCJsonFileAtomically -InputObject @{ Player = 'VLC' } -Path $profilePath
+            Write-LofiATCJsonFileAtomically -InputObject @{ Player = 'MPV'; ATCVolume = 35 } -Path $profilePath
+
+            $profile = Get-Content -LiteralPath $profilePath -Raw | ConvertFrom-Json
+            $profile.Player | Should -Be 'MPV'
+            $profile.ATCVolume | Should -Be 35
+            @(Get-ChildItem -LiteralPath (Split-Path -Parent $profilePath) -Filter '*.tmp').Count | Should -Be 0
+        }
+
+        It 'preserves the active profile and cleans up when a write fails' {
+            $profilePath = Resolve-LofiATCProfilePath -Name 'Work' -CreateDirectory
+            '{"Player":"VLC"}' | Set-Content -LiteralPath $profilePath -Encoding UTF8
+            Mock ConvertTo-Json { throw 'Simulated serialization failure.' }
+
+            { Write-LofiATCJsonFileAtomically -InputObject @{ Player = 'MPV' } -Path $profilePath } |
+                Should -Throw '*Simulated serialization failure*'
+
+            (Get-Content -LiteralPath $profilePath -Raw | ConvertFrom-Json).Player | Should -Be 'VLC'
+            @(Get-ChildItem -LiteralPath (Split-Path -Parent $profilePath) -Filter '*.tmp').Count | Should -Be 0
+        }
+
+        It 'lists profiles in name order and removes only the selected profile' {
+            $profilesPath = Get-LofiATCProfilesPath -Create
+            '{}' | Set-Content -Path (Join-Path $profilesPath 'Zulu.json') -Encoding UTF8
+            '{}' | Set-Content -Path (Join-Path $profilesPath 'Alpha.json') -Encoding UTF8
+
+            (@((Get-LofiATCProfile).Name) -join ',') | Should -Be 'Alpha,Zulu'
+
+            Remove-LofiATCProfile -Name 'Alpha' -InformationAction SilentlyContinue
+
+            Test-Path -LiteralPath (Join-Path $profilesPath 'Alpha.json') | Should -BeFalse
+            Test-Path -LiteralPath (Join-Path $profilesPath 'Zulu.json') | Should -BeTrue
+        }
+
+        It 'reports a missing profile instead of continuing with defaults' {
+            { Import-LofiATCProfile -Name 'Missing' -BoundParameters @{} } |
+                Should -Throw "*Profile 'Missing' was not found*"
+        }
+
+        It 'excludes profile management parameters from saved profile data' {
+            $ignored = Get-LofiATCIgnoredConfigParameterNames
+
+            $ignored | Should -Contain 'Profile'
+            $ignored | Should -Contain 'SaveProfile'
+            $ignored | Should -Contain 'ListProfiles'
+            $ignored | Should -Contain 'RemoveProfile'
+        }
+    }
+
     Context 'Favorites persistence' {
         BeforeEach {
             $script:testDrivePath = Join-Path $TestDrive 'favorites.json'

--- a/tests/lofiatc.Tests.ps1
+++ b/tests/lofiatc.Tests.ps1
@@ -407,7 +407,7 @@ level	page_num	block_num	par_num	line_num	word_num	left	top	width	height	conf	te
     Context 'Named configuration profiles' {
         BeforeEach {
             $script:previousUserDataPath = $env:LOFIATC_USER_DATA
-            $env:LOFIATC_USER_DATA = Join-Path $TestDrive 'user-data'
+            $env:LOFIATC_USER_DATA = Join-Path $TestDrive ('user-data-' + [guid]::NewGuid().ToString('N'))
         }
 
         AfterEach {
@@ -476,6 +476,7 @@ level	page_num	block_num	par_num	line_num	word_num	left	top	width	height	conf	te
             $profile = Get-Content -LiteralPath $profilePath -Raw | ConvertFrom-Json
             $profile.Player | Should -Be 'MPV'
             $profile.ATCVolume | Should -Be 35
+            (Get-Content -LiteralPath ($profilePath + '.bak') -Raw | ConvertFrom-Json).Player | Should -Be 'VLC'
             @(Get-ChildItem -LiteralPath (Split-Path -Parent $profilePath) -Filter '*.tmp').Count | Should -Be 0
         }
 


### PR DESCRIPTION
## What changed

- add `-Profile`, `-SaveProfile`, `-ListProfiles`, and `-RemoveProfile`
- save and restore the selected ICAO/channel without reopening the channel picker
- fall back by channel description when a stream URL changes, or to normal selection when the channel disappears
- store validated named profiles under the user data `profiles` directory
- preserve explicit CLI and selection-mode precedence and the existing `config.json` workflow
- write named profiles atomically through validated temporary JSON and retain the previous version as `.bak`
- add installed-command profile-name completion
- document the workflow and add repository guidance for issue-linked branches
- add Pester coverage for profile validation, channel restoration, fallback behavior, atomic writes, listing, removal, parameter parity, and completion

## Why

Users currently have only one reusable `config.json`. Named profiles allow separate complete listening setups without breaking existing users or requiring the channel to be selected again.

## Validation

- `git diff --check` passes
- GitHub Actions: 108 Pester tests passed, 0 failed

Closes #61
