### PR TITLE
CI: test supported PowerShell platforms

### DIFF
--- a/.github/PSScriptAnalyzerSettings.psd1
+++ b/.github/PSScriptAnalyzerSettings.psd1
@@ -1,0 +1,14 @@
+@{
+  IncludeRules = @(
+    'PSUseCompatibleSyntax'
+  )
+
+  Rules = @{
+    PSUseCompatibleSyntax = @{
+      Enable = $true
+      TargetVersions = @(
+        '5.1'
+      )
+    }
+  }
+}

--- a/.github/workflows/auto-sort-atc.yml
+++ b/.github/workflows/auto-sort-atc.yml
@@ -6,9 +6,17 @@ permissions:
 
 on:
   push:
-    paths: ["atc_sources.csv", "liveatc_sources.csv"]
+    paths:
+      - 'atc_sources.csv'
+      - 'liveatc_sources.csv'
+      - 'tools/Sort-ATCSources.ps1'
+      - '.github/workflows/auto-sort-atc.yml'
   pull_request:
-    paths: ["atc_sources.csv", "liveatc_sources.csv"]
+    paths:
+      - 'atc_sources.csv'
+      - 'liveatc_sources.csv'
+      - 'tools/Sort-ATCSources.ps1'
+      - '.github/workflows/auto-sort-atc.yml'
 
 jobs:
   sort:

--- a/.github/workflows/check_airport_source.yml
+++ b/.github/workflows/check_airport_source.yml
@@ -8,13 +8,11 @@ on:
   push:
     paths:
       - 'atc_sources.csv'
-      - 'liveatc_sources.csv'
       - 'tools/Check-AirportSource.ps1'
       - '.github/workflows/check_airport_source.yml'
   pull_request:
     paths:
       - 'atc_sources.csv'
-      - 'liveatc_sources.csv'
       - 'tools/Check-AirportSource.ps1'
       - '.github/workflows/check_airport_source.yml'
 
@@ -27,7 +25,3 @@ jobs:
       - name: Check base airport source
         shell: pwsh
         run: ./tools/Check-AirportSource.ps1 -CsvPath ./atc_sources.csv
-
-      - name: Check live airport source
-        shell: pwsh
-        run: ./tools/Check-AirportSource.ps1 -CsvPath ./liveatc_sources.csv

--- a/.github/workflows/check_airport_source.yml
+++ b/.github/workflows/check_airport_source.yml
@@ -1,34 +1,33 @@
 name: Check Airport Source
 
 permissions:
-  contents: write
+  contents: read
   pull-requests: read
 
 on:
   push:
-    paths: [ "atc_sources.csv" ]
+    paths:
+      - 'atc_sources.csv'
+      - 'liveatc_sources.csv'
+      - 'tools/Check-AirportSource.ps1'
+      - '.github/workflows/check_airport_source.yml'
   pull_request:
-    paths: [ "atc_sources.csv" ]
+    paths:
+      - 'atc_sources.csv'
+      - 'liveatc_sources.csv'
+      - 'tools/Check-AirportSource.ps1'
+      - '.github/workflows/check_airport_source.yml'
 
 jobs:
   check:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          persist-credentials: true
 
-      - name: Check Airport Source (same-repo branches)
-        if: |
-          github.event_name == 'push' ||
-          (github.event_name == 'pull_request' &&
-           github.event.pull_request.head.repo.full_name == github.repository)
+      - name: Check base airport source
         shell: pwsh
-        run: ./tools/Check-AirportSource.ps1
+        run: ./tools/Check-AirportSource.ps1 -CsvPath ./atc_sources.csv
 
-      - name: Verify (fork PRs)
-        if: |
-          github.event_name == 'pull_request' &&
-          github.event.pull_request.head.repo.full_name != github.repository
+      - name: Check live airport source
         shell: pwsh
-        run: ./tools/Check-AirportSource.ps1
+        run: ./tools/Check-AirportSource.ps1 -CsvPath ./liveatc_sources.csv

--- a/.github/workflows/powershell-tests.yml
+++ b/.github/workflows/powershell-tests.yml
@@ -7,6 +7,7 @@ on:
       - test
       - feature/**
       - enhancement/**
+      - agent/**
     paths:
       - 'lofiatc.ps1'
       - 'install.ps1'
@@ -14,6 +15,10 @@ on:
       - 'modules/**/*.psm1'
       - 'packaging/**/*.ps*1'
       - 'tests/**/*.Tests.ps1'
+      - 'templates/**'
+      - 'tools/**/*.ps1'
+      - '.github/PSScriptAnalyzerSettings.psd1'
+      - '.github/workflows/powershell-tests.yml'
 
   pull_request:
     paths:
@@ -23,11 +28,22 @@ on:
       - 'modules/**/*.psm1'
       - 'packaging/**/*.ps*1'
       - 'tests/**/*.Tests.ps1'
+      - 'templates/**'
+      - 'tools/**/*.ps1'
+      - '.github/PSScriptAnalyzerSettings.psd1'
+      - '.github/workflows/powershell-tests.yml'
 
-    
 jobs:
-  pester-test:
-    runs-on: windows-latest
+  pester-pwsh:
+    name: Pester (PowerShell 7 / ${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - windows-latest
+          - ubuntu-latest
+          - macos-latest
+    runs-on: ${{ matrix.os }}
 
     steps:
       - name: Check out repository code
@@ -36,11 +52,64 @@ jobs:
       - name: Install Pester
         shell: pwsh
         run: |
-          Install-Module Pester -Force -SkipPublisherCheck -Scope CurrentUser
-          Import-Module Pester -Force
+          Install-Module Pester -MinimumVersion 5.5.0 -MaximumVersion 5.99.99 -Force -SkipPublisherCheck -Scope CurrentUser
+          Import-Module Pester -MinimumVersion 5.5.0 -Force
 
       - name: Run Pester tests
         shell: pwsh
         run: |
           $env:LOFIATC_TEST_MODE = '1'
           Invoke-Pester ./tests -CI
+
+  pester-windows-powershell:
+    name: Pester (Windows PowerShell 5.1 / windows-latest)
+    runs-on: windows-latest
+
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v5
+
+      - name: Verify Windows PowerShell 5.1
+        shell: powershell
+        run: |
+          if ($PSVersionTable.PSVersion.Major -ne 5 -or $PSVersionTable.PSVersion.Minor -ne 1) {
+            throw "Expected Windows PowerShell 5.1, got $($PSVersionTable.PSVersion)."
+          }
+
+      - name: Install Pester
+        shell: powershell
+        run: |
+          Install-Module Pester -MinimumVersion 5.5.0 -MaximumVersion 5.99.99 -Force -SkipPublisherCheck -Scope CurrentUser
+          Import-Module Pester -MinimumVersion 5.5.0 -Force
+
+      - name: Run Pester tests
+        shell: powershell
+        run: |
+          $env:LOFIATC_TEST_MODE = '1'
+          Invoke-Pester ./tests -CI
+
+  compatible-syntax:
+    name: PowerShell 5.1-compatible syntax
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v5
+
+      - name: Install PSScriptAnalyzer
+        shell: pwsh
+        run: Install-Module PSScriptAnalyzer -Force -SkipPublisherCheck -Scope CurrentUser
+
+      - name: Analyze PowerShell files
+        shell: pwsh
+        run: |
+          $paths = @('lofiatc.ps1', 'install.ps1', 'uninstall.ps1')
+          $paths += Get-ChildItem modules, packaging, tools, tests -Recurse -File -Include *.ps1, *.psm1, *.psd1 |
+            Select-Object -ExpandProperty FullName
+          $results = @($paths | ForEach-Object {
+            Invoke-ScriptAnalyzer -Path $_ -Settings ./.github/PSScriptAnalyzerSettings.psd1
+          })
+          if ($results.Count -gt 0) {
+            $results | Format-Table -AutoSize | Out-String | Write-Host
+            throw "PSScriptAnalyzer found $($results.Count) PowerShell 5.1 compatibility issue(s)."
+          }

--- a/atc_sources.csv
+++ b/atc_sources.csv
@@ -2008,7 +2008,6 @@
 "North America","United States","Schenectady","New York","Schenectady County Airport","KSCH","SCH","KSCH Ground","https://www.liveatc.net/play/kalb2_ksch_gnd.pls","",""
 "North America","United States","Schenectady","New York","Schenectady County Airport","KSCH","SCH","KSCH Tower","https://www.liveatc.net/play/kalb2_ksch_twr.pls","",""
 "North America","United States","Shirley","New York","Brookhaven Airport","KHWV","HWV","KHWV CTAF","https://www.liveatc.net/play/khwv_ctaf.pls","",""
-"North America","United States","Shirley","New York","Brookhaven Airport","KHWV","HWV","KHWV CTAF","https://www.liveatc.net/play/khwv_ctaf.pls","",""
 "North America","United States","Syracuse","New York","Syracuse Hancock International Airport","KSYR","SYR","KSYR App/Dep","https://www.liveatc.net/play/ksyr_app.pls","",""
 "North America","United States","Syracuse","New York","Syracuse Hancock International Airport","KSYR","SYR","KSYR ATIS","https://www.liveatc.net/play/ksyr_atis.pls","",""
 "North America","United States","Syracuse","New York","Syracuse Hancock International Airport","KSYR","SYR","KSYR Clearance Delivery","https://www.liveatc.net/play/ksyr_del.pls","",""

--- a/packaging/LofiATC/LofiATC.psm1
+++ b/packaging/LofiATC/LofiATC.psm1
@@ -97,7 +97,7 @@ Function Resolve-LofiATCCommit {
         return $Ref.ToLowerInvariant()
     }
 
-    $escapedRef = [System.Uri]::EscapeDataString($Ref)
+    $escapedRef = [System.Uri]::EscapeDataString($Ref) -replace '/', '%2F'
     $commitUrl = "https://api.github.com/repos/$Repository/commits/$escapedRef"
     $commit = Invoke-RestMethod -Uri $commitUrl -Headers @{
         Accept = 'application/vnd.github+json'

--- a/tests/LofiATC.Module.Tests.ps1
+++ b/tests/LofiATC.Module.Tests.ps1
@@ -219,11 +219,11 @@ param(
 
         Mock Invoke-RestMethod -ModuleName LofiATC {
             param(
-                [string]$Uri,
+                [uri]$Uri,
                 [hashtable]$Headers
             )
 
-            $Uri | Should -Be 'https://api.github.com/repos/RoMinjun/lofiatc.ps1/commits/feature%2Finstall-module-command'
+            $Uri.OriginalString | Should -Be 'https://api.github.com/repos/RoMinjun/lofiatc.ps1/commits/feature%2Finstall-module-command'
             return [pscustomobject]@{
                 sha = 'afe8201234567890afe8201234567890afe82012'
             }

--- a/tests/SourceTools.Tests.ps1
+++ b/tests/SourceTools.Tests.ps1
@@ -1,0 +1,59 @@
+BeforeAll {
+  $toolsPath = Join-Path (Join-Path $PSScriptRoot '..') 'tools'
+  $sortScript = Join-Path $toolsPath 'Sort-ATCSources.ps1'
+  $powerShellExecutable = (Get-Process -Id $PID).Path
+
+  function Invoke-SourceSortCheck {
+    param([Parameter(Mandatory)][string]$CsvPath)
+
+    $output = & $powerShellExecutable -NoLogo -NoProfile -File $sortScript `
+      -InputCsvPath $CsvPath -Check 2>&1 | Out-String
+    [pscustomobject]@{
+      ExitCode = $LASTEXITCODE
+      Output = $output
+    }
+  }
+}
+
+Describe 'ATC source validation' {
+  It 'accepts a sorted source with the expected schema and unique rows' {
+    $path = Join-Path $TestDrive 'valid.csv'
+    @'
+"Continent","Country","City","State/Province","Airport Name","ICAO","IATA","Channel Description","Stream URL","Webcam URL","NearbyICAOs"
+"Europe","Netherlands","Amsterdam","","Amsterdam Airport Schiphol","EHAM","AMS","EHAM Tower","https://example.test/eham","",""
+"North America","United States","Seattle","Washington","Seattle-Tacoma International Airport","KSEA","SEA","KSEA Tower","https://example.test/ksea","",""
+'@ | Set-Content -Path $path -Encoding UTF8
+
+    $result = Invoke-SourceSortCheck -CsvPath $path
+
+    $result.ExitCode | Should -Be 0
+    $result.Output | Should -Match 'already sorted'
+  }
+
+  It 'rejects a source with an unexpected schema' {
+    $path = Join-Path $TestDrive 'invalid-schema.csv'
+    @'
+"ICAO","Stream URL"
+"EHAM","https://example.test/eham"
+'@ | Set-Content -Path $path -Encoding UTF8
+
+    $result = Invoke-SourceSortCheck -CsvPath $path
+
+    $result.ExitCode | Should -Be 2
+    $result.Output | Should -Match 'Unexpected CSV schema'
+  }
+
+  It 'rejects exact duplicate rows' {
+    $path = Join-Path $TestDrive 'duplicates.csv'
+    @'
+"Continent","Country","City","State/Province","Airport Name","ICAO","IATA","Channel Description","Stream URL","Webcam URL","NearbyICAOs"
+"Europe","Netherlands","Amsterdam","","Amsterdam Airport Schiphol","EHAM","AMS","EHAM Tower","https://example.test/eham","",""
+"Europe","Netherlands","Amsterdam","","Amsterdam Airport Schiphol","EHAM","AMS","EHAM Tower","https://example.test/eham","",""
+'@ | Set-Content -Path $path -Encoding UTF8
+
+    $result = Invoke-SourceSortCheck -CsvPath $path
+
+    $result.ExitCode | Should -Be 2
+    $result.Output | Should -Match 'duplicate row group'
+  }
+}

--- a/tests/SourceTools.Tests.ps1
+++ b/tests/SourceTools.Tests.ps1
@@ -6,15 +6,27 @@ BeforeAll {
   function Invoke-SourceSortCheck {
     param([Parameter(Mandatory)][string]$CsvPath)
 
-    $errorPath = [System.IO.Path]::GetTempFileName()
+    $startInfo = New-Object System.Diagnostics.ProcessStartInfo
+    $startInfo.FileName = $powerShellExecutable
+    $startInfo.Arguments = '-NoLogo -NoProfile -File "{0}" -InputCsvPath "{1}" -Check' -f `
+      $sortScript, $CsvPath
+    $startInfo.UseShellExecute = $false
+    $startInfo.RedirectStandardOutput = $true
+    $startInfo.RedirectStandardError = $true
+
+    $process = New-Object System.Diagnostics.Process
+    $process.StartInfo = $startInfo
     try {
-      $output = & $powerShellExecutable -NoLogo -NoProfile -File $sortScript `
-        -InputCsvPath $CsvPath -Check 2> $errorPath | Out-String
-      $exitCode = $LASTEXITCODE
-      $output += Get-Content -Path $errorPath -Raw -ErrorAction SilentlyContinue
+      [void]$process.Start()
+      $standardOutput = $process.StandardOutput.ReadToEnd()
+      $standardError = $process.StandardError.ReadToEnd()
+      $process.WaitForExit()
+
+      $exitCode = $process.ExitCode
+      $output = $standardOutput + $standardError
     }
     finally {
-      Remove-Item -Path $errorPath -Force -ErrorAction SilentlyContinue
+      $process.Dispose()
     }
 
     [pscustomobject]@{

--- a/tests/SourceTools.Tests.ps1
+++ b/tests/SourceTools.Tests.ps1
@@ -6,10 +6,19 @@ BeforeAll {
   function Invoke-SourceSortCheck {
     param([Parameter(Mandatory)][string]$CsvPath)
 
-    $output = & $powerShellExecutable -NoLogo -NoProfile -File $sortScript `
-      -InputCsvPath $CsvPath -Check 2>&1 | Out-String
+    $errorPath = [System.IO.Path]::GetTempFileName()
+    try {
+      $output = & $powerShellExecutable -NoLogo -NoProfile -File $sortScript `
+        -InputCsvPath $CsvPath -Check 2> $errorPath | Out-String
+      $exitCode = $LASTEXITCODE
+      $output += Get-Content -Path $errorPath -Raw -ErrorAction SilentlyContinue
+    }
+    finally {
+      Remove-Item -Path $errorPath -Force -ErrorAction SilentlyContinue
+    }
+
     [pscustomobject]@{
-      ExitCode = $LASTEXITCODE
+      ExitCode = $exitCode
       Output = $output
     }
   }

--- a/tests/lofiatc.Tests.ps1
+++ b/tests/lofiatc.Tests.ps1
@@ -141,16 +141,26 @@ level	page_num	block_num	par_num	line_num	word_num	left	top	width	height	conf	te
 
         It 'finds Tesseract in its standard Windows install directory when it is not in PATH' {
             $script:OnWindows = $true
+            $originalProgramFiles = $env:ProgramFiles
+            $env:ProgramFiles = $TestDrive
+            $expectedPath = Join-Path $TestDrive 'Tesseract-OCR\tesseract.exe'
             Mock Test-CommandAvailable { $null }
             Mock Test-Path {
-                $LiteralPath -eq 'C:\Program Files\Tesseract-OCR\tesseract.exe'
+                $LiteralPath -eq $expectedPath
             }
 
-            Resolve-TesseractPath | Should -Be 'C:\Program Files\Tesseract-OCR\tesseract.exe'
+            try {
+                Resolve-TesseractPath | Should -Be $expectedPath
+            }
+            finally {
+                $env:ProgramFiles = $originalProgramFiles
+            }
         }
 
         It 'finds Tesseract from a registered custom installer location' {
             $script:OnWindows = $true
+            $installDirectory = Join-Path $TestDrive 'OCR'
+            $expectedPath = Join-Path $installDirectory 'tesseract.exe'
             Mock Test-CommandAvailable { $null }
             Mock Get-ChildItem {
                 [pscustomobject]@{ PSPath = 'TestRegistry:\Tesseract-OCR' }
@@ -159,13 +169,13 @@ level	page_num	block_num	par_num	line_num	word_num	left	top	width	height	conf	te
             Mock Get-ItemProperty {
                 [pscustomobject]@{
                     DisplayName     = 'Tesseract-OCR'
-                    InstallLocation = 'D:\Tools\OCR'
+                    InstallLocation = $installDirectory
                     DisplayIcon     = $null
                 }
             }
-            Mock Test-Path { $LiteralPath -eq 'D:\Tools\OCR\tesseract.exe' }
+            Mock Test-Path { $LiteralPath -eq $expectedPath }
 
-            Resolve-TesseractPath | Should -Be 'D:\Tools\OCR\tesseract.exe'
+            Resolve-TesseractPath | Should -Be $expectedPath
         }
 
         It 'returns a recent cached OCR result without invoking tools again' {
@@ -308,12 +318,13 @@ level	page_num	block_num	par_num	line_num	word_num	left	top	width	height	conf	te
     Context 'ConvertFrom-METAR' {
         It 'decodes common METAR fields' {
             $decoded = ConvertFrom-METAR 'EGLL 121650Z 18012G20KT 9999 BKN020 18/12 Q1013'
+            $degree = [char]0x00B0
 
             $decoded.Wind | Should -Match '180.*12 knots'
             $decoded.Visibility | Should -Be '10+ km (Unlimited)'
             $decoded.Ceiling | Should -Be 'Broken at 2000 ft'
-            $decoded.Temperature | Should -Be '18°C'
-            $decoded.DewPoint | Should -Be '12°C'
+            $decoded.Temperature | Should -Be "18${degree}C"
+            $decoded.DewPoint | Should -Be "12${degree}C"
             $decoded.Pressure | Should -Be '1013 hPa'
         }
 
@@ -1194,14 +1205,15 @@ level	page_num	block_num	par_num	line_num	word_num	left	top	width	height	conf	te
                 -EnableFavoriteActions
 
             $marker = @($json | ConvertFrom-Json)[0]
+            $star = [regex]::Escape([string][char]0x2605)
 
             $marker.icao | Should -Be 'EHAM'
             $marker.isFav | Should -BeTrue
             $marker.isAirportFav | Should -BeTrue
             $marker.airportFavHtml | Should -Match 'toggleAirportFavorite'
-            $marker.airportFavHtml | Should -Match '★ Remove airport favorite'
+            $marker.airportFavHtml | Should -Match "$star Remove airport favorite"
             $marker.desc | Should -Match 'toggleFavorite'
-            $marker.desc | Should -Match '★ Remove favorite'
+            $marker.desc | Should -Match "$star Remove favorite"
         }
     }
 
@@ -1216,7 +1228,7 @@ ICAO,Channel Description,Stream URL,Webcam URL,NearbyICAOs
 KLAX,Tower,http://example.com/stream,,KSNA;KBUR
 '@ | Set-Content -Path $script:csvPath -Encoding UTF8
 
-            $result = Import-ATCSource -csvPath $script:csvPath
+            $result = @(Import-ATCSource -csvPath $script:csvPath)
             $result.Count | Should -Be 1
             $result[0].ICAO | Should -Be 'KLAX'
         }
@@ -1357,10 +1369,16 @@ KLAX,Tower,http://example.com/stream
     Context 'Start-PlayerProcess' {
         BeforeEach {
             $script:OnWindows = $true
+            $originalAppData = $env:APPDATA
+            $env:APPDATA = $TestDrive
 
             Mock Resolve-StreamUrl { $Url }
             Mock Test-Player { 'C:\Program Files\VideoLAN\VLC\vlc.exe' }
             Mock Start-Process { [System.Diagnostics.Process]::new() }
+        }
+
+        AfterEach {
+            $env:APPDATA = $originalAppData
         }
 
         It 'starts VLC as a separate instance so managed lofi playback remains trackable' {

--- a/tools/Sort-ATCSources.ps1
+++ b/tools/Sort-ATCSources.ps1
@@ -17,6 +17,26 @@ if (-not $rows) {
   exit 2
 }
 
+$expectedCols = @(
+  'Continent', 'Country', 'City', 'State/Province', 'Airport Name',
+  'ICAO', 'IATA', 'Channel Description', 'Stream URL', 'Webcam URL', 'NearbyICAOs'
+)
+$actualCols = @($rows[0].psobject.Properties.Name)
+if (($actualCols.Count -ne $expectedCols.Count) -or
+    (($actualCols -join ',') -cne ($expectedCols -join ','))) {
+  Write-Error "Unexpected CSV schema in '$InputCsvPath'. Expected: $($expectedCols -join ',')"
+  exit 2
+}
+
+$duplicateRows = @($rows | Group-Object {
+  $row = $_
+  ($expectedCols | ForEach-Object { [string]$row.PSObject.Properties[$_].Value }) -join [char]31
+} | Where-Object { $_.Count -gt 1 })
+if ($duplicateRows.Count -gt 0) {
+  Write-Error "Found $($duplicateRows.Count) duplicate row group(s) in '$InputCsvPath'."
+  exit 2
+}
+
 # Grab the filename for dynamic console logging
 $fileName = Split-Path $InputCsvPath -Leaf
 
@@ -32,13 +52,13 @@ $rows | ForEach-Object {
 
 # Canonical sort
 $sorted = $rows | Sort-Object `
-  @{ Expression = { ($_.Continent        ?? '').Trim() } ; Ascending = $true }, `
-  @{ Expression = { ($_.Country          ?? '').Trim() } ; Ascending = $true }, `
+  @{ Expression = { ([string]$_.Continent).Trim() } ; Ascending = $true }, `
+  @{ Expression = { ([string]$_.Country).Trim() } ; Ascending = $true }, `
   @{ Expression = { [string]::IsNullOrWhiteSpace($_.'State/Province') } }, `
-  @{ Expression = { ($_. 'State/Province'?? '').Trim() } ; Ascending = $true }, `
-  @{ Expression = { ($_.City             ?? '').Trim() } ; Ascending = $true }, `
-  @{ Expression = { ($_.ICAO             ?? '').Trim().ToUpper() } ; Ascending = $true }, `
-  @{ Expression = { ($_. 'Channel Description' ?? '').Trim() } ; Ascending = $true }, `
+  @{ Expression = { ([string]$_.'State/Province').Trim() } ; Ascending = $true }, `
+  @{ Expression = { ([string]$_.City).Trim() } ; Ascending = $true }, `
+  @{ Expression = { ([string]$_.ICAO).Trim().ToUpperInvariant() } ; Ascending = $true }, `
+  @{ Expression = { ([string]$_.'Channel Description').Trim() } ; Ascending = $true }, `
   @{ Expression = { $_._idx } }
 
 # Strip helper index

--- a/tools/UpdateATCSources.ps1
+++ b/tools/UpdateATCSources.ps1
@@ -22,13 +22,13 @@ function Sort-AtcRows {
   param([Parameter(Mandatory)][array]$Rows)
 
   $Rows | Sort-Object `
-    @{ Expression = { ($_.Continent        ?? '').Trim() } }, `
-    @{ Expression = { ($_.Country          ?? '').Trim() } }, `
+    @{ Expression = { ([string]$_.Continent).Trim() } }, `
+    @{ Expression = { ([string]$_.Country).Trim() } }, `
     @{ Expression = { [string]::IsNullOrWhiteSpace($_.'State/Province') } }, `
-    @{ Expression = { ($_.'State/Province' ?? '').Trim() } }, `
-    @{ Expression = { ($_.City             ?? '').Trim() } }, `
-    @{ Expression = { ($_.ICAO             ?? '').Trim().ToUpper() } }, `
-    @{ Expression = { ($_.'Channel Description' ?? '').Trim() } }
+    @{ Expression = { ([string]$_.'State/Province').Trim() } }, `
+    @{ Expression = { ([string]$_.City).Trim() } }, `
+    @{ Expression = { ([string]$_.ICAO).Trim().ToUpperInvariant() } }, `
+    @{ Expression = { ([string]$_.'Channel Description').Trim() } }
 }
 
 function Write-AtcCsv {
@@ -249,10 +249,10 @@ $origRows |
   }
 
 $allResults = foreach ($icao in $icaoCache.Keys) {
-  $meta = $origRows | Where-Object { ($_.ICAO ?? '').Trim().ToUpper() -eq $icao } | Select-Object -First 1
+  $meta = $origRows | Where-Object { ([string]$_.ICAO).Trim().ToUpperInvariant() -eq $icao } | Select-Object -First 1
 
   if ($null -eq $icaoCache[$icao]) {
-    $origRows | Where-Object { ($_.ICAO ?? '').Trim().ToUpper() -eq $icao }
+    $origRows | Where-Object { ([string]$_.ICAO).Trim().ToUpperInvariant() -eq $icao }
     continue
   }
 


### PR DESCRIPTION
## Summary
- run Pester on PowerShell 7 across Windows, Ubuntu, and macOS, plus Windows PowerShell 5.1
- enforce PowerShell 5.1-compatible syntax with PSScriptAnalyzer
- trigger tests and source validation for templates, tools, workflows, and both source CSVs
- validate source schemas and exact duplicates, with regression coverage

## Local validation
- workflow YAML parsed successfully
- both source CSV schemas and duplicate sets validated
- git diff --check passed
- PowerShell is unavailable on this host; the PR matrix performs the Pester and analyzer validation

Closes #55