### PR TITLE
Fix CLI help and enforce parameter parity

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,8 @@ Get-Help lofiatc -Full
 | `-Ref` | string | installed ref | Repository ref used by `-UpdateSources`. Available from the installed `lofiatc` command. |
 | `-Repository` | string | installed repository | GitHub `owner/repo` used by `-UpdateSources`. Available from the installed `lofiatc` command. |
 
+CLI parity tests intentionally exclude the installed-command-only parameters `-UpdateSources`, `-Version`, `-SourceDiffLimit`, `-Ref`, and `-Repository`; every other declared parameter is required to match `lofiatc.ps1`.
+
 > [!TIP]
 > Switches are boolean, just include them (no `true/false` needed). CLI overrides always win over loaded config.
 

--- a/lofiatc.ps1
+++ b/lofiatc.ps1
@@ -116,7 +116,7 @@ param (
     [ValidateRange(0,100)]
     [int]$LofiVolume = 50,
     [string]$LofiSource = "https://youtu.be/X4VbdwhkE10",
-    [ValidateSet("Chillhop", "Synthwave", "Jazz", "DarkAmbient","Medieval", "Sad", "Piano", "SleepChill", "RelaxJazz", "Classical", "Guitar", "Pomodoro", "SleepAmbient", "SynthAmbient", "Asian", "DarkAmbient")]
+    [ValidateSet("Chillhop", "Synthwave", "Jazz", "DarkAmbient", "Medieval", "Sad", "Piano", "SleepChill", "RelaxJazz", "Classical", "Guitar", "Pomodoro", "SleepAmbient", "SynthAmbient", "Asian")]
     [string]$LofiGenre,
     [ValidatePattern('^[A-Za-z0-9]{4}$')]
     [string]$ICAO,

--- a/packaging/LofiATC/LofiATC.psm1
+++ b/packaging/LofiATC/LofiATC.psm1
@@ -406,6 +406,99 @@ Streams lofi music with live air traffic control.
 Runs the installed lofiatc.ps1 script while preserving PowerShell-native help,
 parameter completion, and ValidateSet completion for common options.
 
+.PARAMETER IncludeWebcamIfAvailable
+Include webcam video stream if available for the selected ATC source.
+
+.PARAMETER NoLofiMusic
+Do not play Lofi music.
+
+.PARAMETER RandomATC
+Select a random ATC stream from the list of sources. When combined with -ICAO,
+choose a random channel for that airport.
+
+.PARAMETER PlayLofiGirlVideo
+Play the Lofi Girl video instead of just the audio.
+
+.PARAMETER ShowLofiTrack
+Uses OCR to show the current Lofi Girl track in persistent map mode. Requires yt-dlp or youtube-dl, ffmpeg, and Tesseract OCR.
+
+.PARAMETER UseFZF
+Use fzf for searching and filtering channels.
+
+.PARAMETER UseBaseCSV
+Force the script to load atc_sources.csv even if liveatc_sources.csv exists.
+
+.PARAMETER UseFavorite
+Load a previously saved favorite from favorites.json and skip continent/country selection. The file stores how often you play each stream and keeps the top entries.
+
+.PARAMETER Player
+Specify the media player to use (VLC, Potplayer, MPC-HC or MPV).
+
+If not specified, the script auto-detects a suitable player:
+- On Windows, it first checks the default app for .mp4 and uses it if supported and available in PATH.
+- If no supported default is available, it falls back to the first supported installed player.
+- On non-Windows systems, it prefers MPV first, then VLC.
+
+.PARAMETER ATCVolume
+Volume level for the ATC stream. Default is 65.
+
+.PARAMETER LofiVolume
+Volume level for the Lofi Girl stream. Default is 50.
+
+.PARAMETER LofiSource
+Specify a custom URL or file path for the Lofi audio/video source Defaults to the Lofi Girl Youtube stream if not provided.
+
+.PARAMETER LofiGenre
+Specify a Lofi genre preset. Valid options: Chillhop, Synthwave, SynthAmbient, Sad, Piano, Classical, Jazz, RelaxJazz, SleepAmbient, DarkAmbient, Medieval, Asian, SleepChill, Guitar, Pomodoro. This is overridden by -LofiSource.
+
+.PARAMETER ICAO
+Specify an airport by ICAO code. If multiple channels exist you will be prompted to select one unless -RandomATC is used to choose randomly.
+
+.PARAMETER OpenRadar
+Open the FlightAware radar page for the selected ICAO after displaying the welcome screen.
+
+.PARAMETER SaveConfig
+Save the parameters used for the current run to a configuration file.
+
+.PARAMETER LoadConfig
+Load options from the default or custom configuration file. Explicit command-line values take precedence.
+
+.PARAMETER ConfigPath
+Optional path for the saved configuration file. Defaults to user data when installed, with repo-local config as a compatibility fallback.
+
+.PARAMETER Profile
+Load a named profile from the user data directory. Explicit command-line values take precedence.
+
+.PARAMETER SaveProfile
+Save the current options and selected ATC channel as a named profile in the user data directory.
+
+.PARAMETER ListProfiles
+List saved named profiles and exit without starting playback.
+
+.PARAMETER RemoveProfile
+Remove a named profile and exit without starting playback.
+
+.PARAMETER Nearby
+Shows a list of nearby airports to your current device location (IP as fallback)
+
+.PARAMETER NearbyRadius
+If specified, to be used in combination with -Nearby, to change the radius of nearby airports in kilometers
+
+.PARAMETER ShowMap
+Generates and opens an interactive HTML map in your browser showing all available ATC sources.
+
+.PARAMETER NoWeather
+Skips the live METAR weather fetch when loading the map to vastly improve startup speed.
+
+.PARAMETER Dark
+Initializes the HTML Map in Dark Mode.
+
+.PARAMETER CheckDependencies
+Checks required files, player availability, optional tools, and network dependencies, then prints a dependency report and exits.
+
+.PARAMETER KeepOpen
+When used with -ShowMap, keeps the interactive map open after selecting a channel and allows repeated channel selections from the map.
+
 .PARAMETER UpdateSources
 Refreshes liveatc_sources.csv in the installed app directory and exits.
 
@@ -418,20 +511,8 @@ Limits the number of added and removed sources printed by -UpdateSources. Use 0 
 .PARAMETER Ref
 Repository ref to use with -UpdateSources. Defaults to the ref recorded by the installer.
 
-.PARAMETER ShowLofiTrack
-Uses OCR to show the current Lofi Girl track in persistent map mode.
-
-.PARAMETER Profile
-Loads a named configuration profile. Explicit command-line values take precedence.
-
-.PARAMETER SaveProfile
-Saves the current options and selected ATC channel as a named configuration profile.
-
-.PARAMETER ListProfiles
-Lists saved named profiles without starting playback.
-
-.PARAMETER RemoveProfile
-Removes a named configuration profile without starting playback.
+.PARAMETER Repository
+GitHub owner/repository used by -UpdateSources. Defaults to the repository recorded by the installer.
 #>
     [CmdletBinding()]
     param (

--- a/tests/LofiATC.Module.Tests.ps1
+++ b/tests/LofiATC.Module.Tests.ps1
@@ -75,8 +75,16 @@ Describe 'LofiATC module updater' {
 
             $scriptCommand = Get-Command $scriptEntryPoint
             $wrapperCommand = Get-Command lofiatc
+            $wrapperParseTokens = $null
+            $wrapperParseErrors = $null
+            $wrapperAst = [System.Management.Automation.Language.Parser]::ParseInput(
+                $wrapperCommand.Definition,
+                [ref]$wrapperParseTokens,
+                [ref]$wrapperParseErrors
+            )
+            $wrapperParseErrors | Should -BeNullOrEmpty
             $scriptAstParameters = Get-TestParameterAstMap -ParamBlock $scriptAst.ParamBlock
-            $wrapperAstParameters = Get-TestParameterAstMap -ParamBlock $wrapperCommand.ScriptBlock.Ast.ParamBlock
+            $wrapperAstParameters = Get-TestParameterAstMap -ParamBlock $wrapperAst.ParamBlock
             $scriptNames = @($scriptAstParameters.Keys | Sort-Object)
             $forwardedWrapperNames = @(
                 $wrapperAstParameters.Keys |

--- a/tests/LofiATC.Module.Tests.ps1
+++ b/tests/LofiATC.Module.Tests.ps1
@@ -20,7 +20,7 @@ Describe 'LofiATC module updater' {
         }
 
         function Get-TestValidationSignature {
-            param([System.Management.Automation.CommandParameterInfo]$Parameter)
+            param([System.Management.Automation.ParameterMetadata]$Parameter)
 
             $signatures = @()
             foreach ($attribute in $Parameter.Attributes) {

--- a/tests/LofiATC.Module.Tests.ps1
+++ b/tests/LofiATC.Module.Tests.ps1
@@ -3,9 +3,47 @@ Set-StrictMode -Version Latest
 Describe 'LofiATC module updater' {
     BeforeAll {
         $repoRoot = Split-Path -Parent $PSScriptRoot
+        $scriptEntryPoint = Join-Path $repoRoot 'lofiatc.ps1'
         $moduleManifest = Join-Path $repoRoot 'packaging/LofiATC/LofiATC.psd1'
+        $installedOnlyParameters = @('UpdateSources', 'Version', 'SourceDiffLimit', 'Ref', 'Repository')
         Remove-Module LofiATC -Force -ErrorAction SilentlyContinue
         Import-Module $moduleManifest -Force
+
+        function Get-TestParameterAstMap {
+            param([System.Management.Automation.Language.ParamBlockAst]$ParamBlock)
+
+            $result = @{}
+            foreach ($parameter in $ParamBlock.Parameters) {
+                $result[$parameter.Name.VariablePath.UserPath] = $parameter
+            }
+            return $result
+        }
+
+        function Get-TestValidationSignature {
+            param([System.Management.Automation.CommandParameterInfo]$Parameter)
+
+            $signatures = @()
+            foreach ($attribute in $Parameter.Attributes) {
+                if ($attribute -is [System.Management.Automation.ValidateSetAttribute]) {
+                    $values = @($attribute.ValidValues | Sort-Object)
+                    $signatures += 'ValidateSet:{0}' -f ($values -join ',')
+                }
+                elseif ($attribute -is [System.Management.Automation.ValidateRangeAttribute]) {
+                    $signatures += 'ValidateRange:{0},{1}' -f $attribute.MinRange, $attribute.MaxRange
+                }
+                elseif ($attribute -is [System.Management.Automation.ValidatePatternAttribute]) {
+                    $signatures += 'ValidatePattern:{0}' -f $attribute.RegexPattern
+                }
+            }
+            return (@($signatures | Sort-Object) -join ';')
+        }
+
+        function Get-TestHelpDescription {
+            param($ParameterHelp)
+
+            $text = @($ParameterHelp.Description | ForEach-Object { $_.Text }) -join ' '
+            return (($text -replace '\s+', ' ').Trim())
+        }
     }
 
     AfterAll {
@@ -22,6 +60,86 @@ Describe 'LofiATC module updater' {
 
         $profilePattern = @($parameters.Profile.Attributes | Where-Object { $_ -is [System.Management.Automation.ValidatePatternAttribute] })[0]
         $profilePattern.RegexPattern | Should -Be '^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$'
+    }
+
+    Context 'CLI parameter parity' {
+        It 'keeps shared names, types, aliases, defaults, and validation rules aligned' {
+            $parseTokens = $null
+            $parseErrors = $null
+            $scriptAst = [System.Management.Automation.Language.Parser]::ParseFile(
+                $scriptEntryPoint,
+                [ref]$parseTokens,
+                [ref]$parseErrors
+            )
+            $parseErrors | Should -BeNullOrEmpty
+
+            $scriptCommand = Get-Command $scriptEntryPoint
+            $wrapperCommand = Get-Command lofiatc
+            $scriptAstParameters = Get-TestParameterAstMap -ParamBlock $scriptAst.ParamBlock
+            $wrapperAstParameters = Get-TestParameterAstMap -ParamBlock $wrapperCommand.ScriptBlock.Ast.ParamBlock
+            $scriptNames = @($scriptAstParameters.Keys | Sort-Object)
+            $forwardedWrapperNames = @(
+                $wrapperAstParameters.Keys |
+                    Where-Object { $_ -notin $installedOnlyParameters } |
+                    Sort-Object
+            )
+
+            Compare-Object $scriptNames $forwardedWrapperNames | Should -BeNullOrEmpty
+
+            foreach ($name in $scriptNames) {
+                $scriptParameter = $scriptCommand.Parameters[$name]
+                $wrapperParameter = $wrapperCommand.Parameters[$name]
+                $scriptDefault = $scriptAstParameters[$name].DefaultValue
+                $wrapperDefault = $wrapperAstParameters[$name].DefaultValue
+
+                $wrapperParameter.ParameterType.FullName | Should -Be $scriptParameter.ParameterType.FullName
+                (@($wrapperParameter.Aliases | Sort-Object) -join ',') |
+                    Should -Be (@($scriptParameter.Aliases | Sort-Object) -join ',')
+                (Get-TestValidationSignature -Parameter $wrapperParameter) |
+                    Should -Be (Get-TestValidationSignature -Parameter $scriptParameter)
+
+                if ($null -eq $scriptDefault) {
+                    $wrapperDefault | Should -BeNullOrEmpty
+                }
+                else {
+                    $wrapperDefault.Extent.Text | Should -Be $scriptDefault.Extent.Text
+                }
+            }
+        }
+
+        It 'limits intentional wrapper-only parameters to the documented updater controls' {
+            $scriptParameters = (Get-Command $scriptEntryPoint).Parameters
+            $wrapperParameters = (Get-Command lofiatc).Parameters
+
+            foreach ($name in $installedOnlyParameters) {
+                $wrapperParameters.Keys | Should -Contain $name
+                $scriptParameters.Keys | Should -Not -Contain $name
+            }
+        }
+
+        It 'documents every shared parameter consistently in both help surfaces' {
+            $parseTokens = $null
+            $parseErrors = $null
+            $scriptAst = [System.Management.Automation.Language.Parser]::ParseFile(
+                $scriptEntryPoint,
+                [ref]$parseTokens,
+                [ref]$parseErrors
+            )
+            $scriptAstParameters = Get-TestParameterAstMap -ParamBlock $scriptAst.ParamBlock
+            $scriptNames = @($scriptAstParameters.Keys)
+            $scriptHelp = Get-Help $scriptEntryPoint -Full
+            $wrapperHelp = Get-Help lofiatc -Full
+
+            foreach ($name in $scriptNames) {
+                $scriptParameterHelp = @($scriptHelp.Parameters.Parameter | Where-Object Name -eq $name)[0]
+                $wrapperParameterHelp = @($wrapperHelp.Parameters.Parameter | Where-Object Name -eq $name)[0]
+                $scriptDescription = Get-TestHelpDescription -ParameterHelp $scriptParameterHelp
+                $wrapperDescription = Get-TestHelpDescription -ParameterHelp $wrapperParameterHelp
+
+                $scriptDescription | Should -Not -BeNullOrEmpty
+                $wrapperDescription | Should -Be $scriptDescription
+            }
+        }
     }
 
     It 'completes saved profile names' {


### PR DESCRIPTION
## Summary

- remove the duplicate `DarkAmbient` entry from the script ValidateSet
- document every shared option consistently in script and installed-command help
- add a PowerShell AST/metadata contract test for shared names, types, aliases, defaults, ValidateSet values, ranges, and patterns
- document the five intentionally installed-only updater parameters

## Why

The public CLI is declared by both `lofiatc.ps1` and the installed `lofiatc` wrapper. Without an automated comparison, validation and help can drift between those entrypoints.

## Validation

- static help comparison passed for all 29 shared parameters
- LofiGenre ValidateSet contains 15 unique values
- `git diff --check` passed
- the PR CI matrix runs Pester under Windows PowerShell 5.1 and PowerShell 7 on Windows, Ubuntu, and macOS

Closes #58
