### PR TITLE
Make favorites and configuration writes recoverable

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,6 +366,8 @@ Even if your config has `OpenRadar: false`, you can re-enable it with:
 lofiatc -LoadConfig -OpenRadar
 ```
 
+Configuration and profile files are written through a validated temporary file before replacement. When an existing file is valid, its previous contents are retained in a neighboring `.bak` file. If the active JSON becomes malformed, LofiATC warns and attempts to load the last-known-good backup without modifying the damaged file. A later save preserves malformed JSON in a uniquely named `.corrupt-*.bak` file before replacing it.
+
 ### Named profiles
 
 Named profiles let you keep several reusable setups while preserving the existing `config.json` behavior. Profile names are 1–64 letters, numbers, underscores, or hyphens and must start with a letter or number.
@@ -408,6 +410,7 @@ Each time you select a stream, its ICAO and channel are recorded in your user `f
 
 - Use `-UseFavorite` to pick from this list (combine with `-UseFZF` to search within favorites).
 - Streams chosen with `-RandomATC` aren't saved to the favorites list.
+- Favorites writes use the same validated replacement and backup behavior as configuration files. If `favorites.json` is malformed, LofiATC warns and uses `favorites.json.bak` when it is valid; damaged JSON is preserved before any later write.
 
 **Example `favorites.json`**
 ```json

--- a/modules/LofiATC.Core.psm1
+++ b/modules/LofiATC.Core.psm1
@@ -214,49 +214,115 @@ Function Get-LofiATCProfile {
 Function Write-LofiATCJsonFileAtomically {
     param(
         [object]$InputObject,
-        [string]$Path
+        [string]$Path,
+        [scriptblock]$FileValidator
     )
 
-    $directory = Split-Path -Parent $Path
-    if ($directory -and -not (Test-Path -LiteralPath $directory)) {
+    $resolvedPath = [System.IO.Path]::GetFullPath($Path)
+    $directory = [System.IO.Path]::GetDirectoryName($resolvedPath)
+    if (-not (Test-Path -LiteralPath $directory)) {
         New-Item -ItemType Directory -Path $directory -Force | Out-Null
     }
 
-    $fileName = Split-Path -Leaf $Path
+    $fileName = [System.IO.Path]::GetFileName($resolvedPath)
     $temporaryPath = Join-Path $directory ('.{0}.{1}.tmp' -f $fileName, [guid]::NewGuid().ToString('N'))
-    $backupPath = $Path + '.bak'
+    $backupTemporaryPath = $null
+    $backupPath = $resolvedPath + '.bak'
 
     try {
-        $json = $InputObject | ConvertTo-Json
+        $json = ConvertTo-Json -InputObject $InputObject -Depth 10
         $utf8WithoutBom = New-Object System.Text.UTF8Encoding($false)
         [System.IO.File]::WriteAllText($temporaryPath, $json, $utf8WithoutBom)
 
         # Validate the complete temporary file before it can replace user data.
-        $null = Get-Content -LiteralPath $temporaryPath -Raw | ConvertFrom-Json
-
-        if (Test-Path -LiteralPath $Path) {
-            if (Test-Path -LiteralPath $backupPath) {
-                Remove-Item -LiteralPath $backupPath -Force
-            }
-
-            [System.IO.File]::Replace($temporaryPath, $Path, $backupPath)
+        if ($FileValidator) {
+            & $FileValidator $temporaryPath
         }
         else {
-            [System.IO.File]::Move($temporaryPath, $Path)
+            $null = Get-Content -LiteralPath $temporaryPath -Raw | ConvertFrom-Json
+        }
+
+        if (Test-Path -LiteralPath $resolvedPath) {
+            $activeFileIsValid = $true
+            try {
+                if ($FileValidator) {
+                    & $FileValidator $resolvedPath
+                }
+                else {
+                    $null = Get-Content -LiteralPath $resolvedPath -Raw | ConvertFrom-Json
+                }
+            }
+            catch {
+                $activeFileIsValid = $false
+            }
+
+            if ($activeFileIsValid) {
+                $backupTemporaryPath = Join-Path $directory ('.{0}.{1}.bak.tmp' -f $fileName, [guid]::NewGuid().ToString('N'))
+                [System.IO.File]::Copy($resolvedPath, $backupTemporaryPath)
+                if ($FileValidator) {
+                    & $FileValidator $backupTemporaryPath
+                }
+                else {
+                    $null = Get-Content -LiteralPath $backupTemporaryPath -Raw | ConvertFrom-Json
+                }
+                Move-LofiATCFileAtomically -SourcePath $backupTemporaryPath -DestinationPath $backupPath
+                $backupTemporaryPath = $null
+            }
+            else {
+                $timestamp = (Get-Date).ToUniversalTime().ToString('yyyyMMddTHHmmssZ')
+                $corruptBackupPath = '{0}.corrupt-{1}-{2}.bak' -f $resolvedPath, $timestamp, [guid]::NewGuid().ToString('N').Substring(0, 8)
+                [System.IO.File]::Copy($resolvedPath, $corruptBackupPath)
+                Write-Warning "Existing JSON at '$resolvedPath' is malformed or invalid. It was preserved at '$corruptBackupPath' before replacement."
+            }
+
+            Move-LofiATCFileAtomically -SourcePath $temporaryPath -DestinationPath $resolvedPath
+        }
+        else {
+            Move-LofiATCFileAtomically -SourcePath $temporaryPath -DestinationPath $resolvedPath
         }
     }
     finally {
         if (Test-Path -LiteralPath $temporaryPath) {
             Remove-Item -LiteralPath $temporaryPath -Force
         }
+
+        if ($backupTemporaryPath -and (Test-Path -LiteralPath $backupTemporaryPath)) {
+            Remove-Item -LiteralPath $backupTemporaryPath -Force
+        }
     }
+}
+
+Function Move-LofiATCFileAtomically {
+    param(
+        [string]$SourcePath,
+        [string]$DestinationPath
+    )
+
+    if (Test-Path -LiteralPath $DestinationPath) {
+        [System.IO.File]::Replace($SourcePath, $DestinationPath, $null)
+    }
+    else {
+        [System.IO.File]::Move($SourcePath, $DestinationPath)
+    }
+}
+
+Function Read-LofiATCConfigFile {
+    param([string]$Path)
+
+    $config = Get-Content -LiteralPath $Path -Raw | ConvertFrom-Json
+    if ($null -eq $config -or $config -isnot [pscustomobject]) {
+        throw "The file does not contain a JSON configuration object."
+    }
+
+    return $config
 }
 
 Function Import-LofiATCConfig {
     param(
         [string]$ConfigPath,
         [hashtable]$BoundParameters,
-        [int]$VariableScope = 1
+        [int]$VariableScope = 1,
+        [switch]$PassThru
     )
 
     if (-not (Test-Path $ConfigPath)) {
@@ -265,7 +331,28 @@ Function Import-LofiATCConfig {
     }
 
     $ignoredParameters = Get-LofiATCIgnoredConfigParameterNames
-    $config = Get-Content -Path $ConfigPath | ConvertFrom-Json
+    $config = $null
+
+    try {
+        $config = Read-LofiATCConfigFile -Path $ConfigPath
+    }
+    catch {
+        Write-Warning "Config file at '$ConfigPath' is malformed or invalid and was left unchanged: $($_.Exception.Message)"
+        $backupPath = $ConfigPath + '.bak'
+        if (Test-Path -LiteralPath $backupPath) {
+            try {
+                $config = Read-LofiATCConfigFile -Path $backupPath
+                Write-Warning "Recovered configuration values from backup '$backupPath'."
+            }
+            catch {
+                Write-Warning "Config backup at '$backupPath' is also malformed or invalid: $($_.Exception.Message)"
+            }
+        }
+    }
+
+    if ($null -eq $config) {
+        return
+    }
 
     foreach ($prop in $config.PSObject.Properties) {
         $name = $prop.Name
@@ -279,13 +366,15 @@ Function Import-LofiATCConfig {
     }
 
     Write-Information "Loaded config from $ConfigPath"
+    if ($PassThru) {
+        return $config
+    }
 }
 
 Function Export-LofiATCConfig {
     param(
         [string]$CommandPath,
         [string]$ConfigPath,
-        [switch]$Atomic,
         [int]$VariableScope = 1,
         [hashtable]$AdditionalValues
     )
@@ -320,11 +409,9 @@ Function Export-LofiATCConfig {
         New-Item -ItemType Directory -Path $configDir -Force | Out-Null
     }
 
-    if ($Atomic) {
-        Write-LofiATCJsonFileAtomically -InputObject $config -Path $ConfigPath
-    }
-    else {
-        $config | ConvertTo-Json | Set-Content -Path $ConfigPath
+    Write-LofiATCJsonFileAtomically -InputObject $config -Path $ConfigPath -FileValidator {
+        param($CandidatePath)
+        $null = Read-LofiATCConfigFile -Path $CandidatePath
     }
     Write-Information "Saved config to $ConfigPath"
 }
@@ -340,9 +427,10 @@ Function Import-LofiATCProfile {
         throw "Profile '$Name' was not found. Use -ListProfiles to view saved profiles."
     }
 
-    Import-LofiATCConfig -ConfigPath $profilePath -BoundParameters $BoundParameters -VariableScope 2
-
-    $profile = Get-Content -LiteralPath $profilePath -Raw | ConvertFrom-Json
+    $profile = Import-LofiATCConfig -ConfigPath $profilePath -BoundParameters $BoundParameters -VariableScope 2 -PassThru
+    if ($null -eq $profile) {
+        return
+    }
     if ($profile.PSObject.Properties['SelectedChannel']) {
         return $profile.SelectedChannel
     }
@@ -381,7 +469,6 @@ Function Export-LofiATCProfile {
     Export-LofiATCConfig `
         -CommandPath $CommandPath `
         -ConfigPath $profilePath `
-        -Atomic `
         -VariableScope 2 `
         -AdditionalValues $additionalValues
 }

--- a/modules/LofiATC.Core.psm1
+++ b/modules/LofiATC.Core.psm1
@@ -299,7 +299,17 @@ Function Move-LofiATCFileAtomically {
     )
 
     if (Test-Path -LiteralPath $DestinationPath) {
-        [System.IO.File]::Replace($SourcePath, $DestinationPath, $null)
+        $destinationDirectory = [System.IO.Path]::GetDirectoryName($DestinationPath)
+        $destinationFileName = [System.IO.Path]::GetFileName($DestinationPath)
+        $replacedFilePath = Join-Path $destinationDirectory ('.{0}.{1}.replaced.tmp' -f $destinationFileName, [guid]::NewGuid().ToString('N'))
+        try {
+            [System.IO.File]::Replace($SourcePath, $DestinationPath, $replacedFilePath)
+        }
+        finally {
+            if (Test-Path -LiteralPath $replacedFilePath) {
+                Remove-Item -LiteralPath $replacedFilePath -Force -ErrorAction SilentlyContinue
+            }
+        }
     }
     else {
         [System.IO.File]::Move($SourcePath, $DestinationPath)

--- a/modules/LofiATC.Favorites.psm1
+++ b/modules/LofiATC.Favorites.psm1
@@ -7,25 +7,48 @@ Function Get-Favorite {
     }
 
     try {
-        $data = Get-Content -Path $path -Raw | ConvertFrom-Json
+        $result = Read-LofiATCFavoriteFile -Path $path
+        return @($result.Items)
     }
     catch {
-        return @()
+        Write-Warning "Favorites file at '$path' is malformed or invalid and was left unchanged: $($_.Exception.Message)"
     }
 
-    if ($null -eq $data) {
-        return @()
+    $backupPath = $path + '.bak'
+    if (Test-Path -LiteralPath $backupPath) {
+        try {
+            $result = Read-LofiATCFavoriteFile -Path $backupPath
+            Write-Warning "Recovered favorites from backup '$backupPath'."
+            return @($result.Items)
+        }
+        catch {
+            Write-Warning "Favorites backup at '$backupPath' is also malformed or invalid: $($_.Exception.Message)"
+        }
     }
 
+    return @()
+}
+
+Function Read-LofiATCFavoriteFile {
+    param([string]$Path)
+
+    $rawJson = Get-Content -LiteralPath $Path -Raw
+    $data = $rawJson | ConvertFrom-Json
     $items = @($data)
 
-    if ($items.Count -eq 1 -and $items[0] -is [string]) {
-        return @()
+    if ($null -eq $data) {
+        if ($rawJson.Trim() -ne '[]') {
+            throw 'The file does not contain a JSON favorites array.'
+        }
+        $items = @()
+    }
+    elseif ($items.Count -eq 1 -and $items[0] -is [string]) {
+        throw 'The file does not contain a JSON favorites array.'
     }
 
     foreach ($f in $items) {
         if (-not $f.PSObject.Properties['ICAO'] -or -not $f.PSObject.Properties['Channel']) {
-            return @()
+            throw 'A favorite entry is missing its ICAO or Channel value.'
         }
 
         if (-not $f.PSObject.Properties['Count']) {
@@ -37,7 +60,7 @@ Function Get-Favorite {
         }
     }
 
-    return $items
+    return [pscustomobject]@{ Items = @($items) }
 }
 
 # Function to save favorites back to the JSON file
@@ -49,14 +72,11 @@ Function Save-Favorite {
         New-Item -ItemType Directory -Path $favoriteDir -Force | Out-Null
     }
 
-    $items = @($favorites)
-
-    if ($items.Count -eq 0) {
-        '[]' | Set-Content -Path $path
-        return
+    $items = [object[]]@($favorites)
+    Write-LofiATCJsonFileAtomically -InputObject $items -Path $path -FileValidator {
+        param($CandidatePath)
+        $null = Read-LofiATCFavoriteFile -Path $CandidatePath
     }
-
-    $items | ConvertTo-Json -Depth 5 | Set-Content -Path $path
 }
 
 # Function to add or update a favorite entry

--- a/modules/LofiATC.Favorites.psm1
+++ b/modules/LofiATC.Favorites.psm1
@@ -3,7 +3,7 @@ Function Get-Favorite {
     param([string]$path)
 
     if (-not (Test-Path $path)) {
-        return @()
+        return
     }
 
     try {
@@ -26,7 +26,7 @@ Function Get-Favorite {
         }
     }
 
-    return @()
+    return
 }
 
 Function Read-LofiATCFavoriteFile {

--- a/tests/lofiatc.Tests.ps1
+++ b/tests/lofiatc.Tests.ps1
@@ -809,8 +809,8 @@ level	page_num	block_num	par_num	line_num	word_num	left	top	width	height	conf	te
             Add-Favorite -path $script:testDrivePath -ICAO 'KLAX' -Channel 'Tower' -maxEntries 10
             Add-Favorite -path $script:testDrivePath -ICAO 'EHAM' -Channel 'Ground' -maxEntries 10
 
-            $activeFavorites = @(Get-Content -LiteralPath $script:testDrivePath -Raw | ConvertFrom-Json)
-            $backupFavorites = @(Get-Content -LiteralPath ($script:testDrivePath + '.bak') -Raw | ConvertFrom-Json)
+            $activeFavorites = @(Get-Favorite -path $script:testDrivePath)
+            $backupFavorites = @(Get-Favorite -path ($script:testDrivePath + '.bak'))
 
             $activeFavorites.Count | Should -Be 2
             $backupFavorites.Count | Should -Be 1

--- a/tests/lofiatc.Tests.ps1
+++ b/tests/lofiatc.Tests.ps1
@@ -415,6 +415,90 @@ level	page_num	block_num	par_num	line_num	word_num	left	top	width	height	conf	te
         }
     }
 
+    Context 'Recoverable JSON persistence' {
+        It 'keeps the previous JSON as a last-known-good backup' {
+            $jsonPath = Join-Path $TestDrive 'recoverable-config.json'
+
+            Write-LofiATCJsonFileAtomically -InputObject @{ Player = 'VLC' } -Path $jsonPath
+            Write-LofiATCJsonFileAtomically -InputObject @{ Player = 'MPV' } -Path $jsonPath
+
+            (Get-Content -LiteralPath $jsonPath -Raw | ConvertFrom-Json).Player | Should -Be 'MPV'
+            (Get-Content -LiteralPath ($jsonPath + '.bak') -Raw | ConvertFrom-Json).Player | Should -Be 'VLC'
+            @(Get-ChildItem -LiteralPath $TestDrive -Filter '*.tmp').Count | Should -Be 0
+        }
+
+        It 'uses atomic replacement for normal saved configuration' {
+            $commandPath = Join-Path $TestDrive 'config-command.ps1'
+            $configPath = Join-Path $TestDrive 'saved-config.json'
+            'param([string]$Player)' | Set-Content -LiteralPath $commandPath -Encoding UTF8
+            $Player = 'VLC'
+
+            Export-LofiATCConfig -CommandPath $commandPath -ConfigPath $configPath -VariableScope 1
+            $Player = 'MPV'
+            Export-LofiATCConfig -CommandPath $commandPath -ConfigPath $configPath -VariableScope 1
+
+            (Get-Content -LiteralPath $configPath -Raw | ConvertFrom-Json).Player | Should -Be 'MPV'
+            (Get-Content -LiteralPath ($configPath + '.bak') -Raw | ConvertFrom-Json).Player | Should -Be 'VLC'
+        }
+
+        It 'preserves malformed active JSON before replacing it' {
+            $jsonPath = Join-Path $TestDrive 'malformed-config.json'
+            '{broken-json' | Set-Content -LiteralPath $jsonPath -Encoding UTF8
+            Mock Write-Warning
+
+            Write-LofiATCJsonFileAtomically -InputObject @{ Player = 'MPV' } -Path $jsonPath
+
+            (Get-Content -LiteralPath $jsonPath -Raw | ConvertFrom-Json).Player | Should -Be 'MPV'
+            $corruptBackups = @(Get-ChildItem -LiteralPath $TestDrive -Filter 'malformed-config.json.corrupt-*.bak')
+            $corruptBackups.Count | Should -Be 1
+            (Get-Content -LiteralPath $corruptBackups[0].FullName -Raw) | Should -Match 'broken-json'
+            Should -Invoke Write-Warning -Times 1 -Exactly -ParameterFilter {
+                $Message -match 'malformed or invalid.*preserved'
+            }
+        }
+
+        It 'preserves the active file and cleans temporary files when replacement fails' {
+            $script:failedConfigPath = Join-Path $TestDrive 'failed-config.json'
+            '{"Player":"VLC"}' | Set-Content -LiteralPath $script:failedConfigPath -Encoding UTF8
+            Mock Move-LofiATCFileAtomically {
+                param($SourcePath, $DestinationPath)
+
+                if ($DestinationPath -eq ($script:failedConfigPath + '.bak')) {
+                    [System.IO.File]::Move($SourcePath, $DestinationPath)
+                    return
+                }
+
+                throw 'Simulated replacement failure.'
+            }
+
+            { Write-LofiATCJsonFileAtomically -InputObject @{ Player = 'MPV' } -Path $script:failedConfigPath } |
+                Should -Throw '*Simulated replacement failure*'
+
+            (Get-Content -LiteralPath $script:failedConfigPath -Raw | ConvertFrom-Json).Player | Should -Be 'VLC'
+            (Get-Content -LiteralPath ($script:failedConfigPath + '.bak') -Raw | ConvertFrom-Json).Player | Should -Be 'VLC'
+            @(Get-ChildItem -LiteralPath $TestDrive -Filter '*.tmp').Count | Should -Be 0
+        }
+
+        It 'loads configuration from the backup when the active file is malformed' {
+            $configPath = Join-Path $TestDrive 'recover-config.json'
+            '{broken-json' | Set-Content -LiteralPath $configPath -Encoding UTF8
+            '{"Player":"VLC"}' | Set-Content -LiteralPath ($configPath + '.bak') -Encoding UTF8
+            $Player = 'MPV'
+            Mock Write-Warning
+
+            Import-LofiATCConfig -ConfigPath $configPath -BoundParameters @{} -VariableScope 1
+
+            $Player | Should -Be 'VLC'
+            (Get-Content -LiteralPath $configPath -Raw) | Should -Match 'broken-json'
+            Should -Invoke Write-Warning -Times 1 -Exactly -ParameterFilter {
+                $Message -match 'malformed or invalid.*left unchanged'
+            }
+            Should -Invoke Write-Warning -Times 1 -Exactly -ParameterFilter {
+                $Message -match 'Recovered configuration values from backup'
+            }
+        }
+    }
+
     Context 'Named configuration profiles' {
         BeforeEach {
             $script:previousUserDataPath = $env:LOFIATC_USER_DATA
@@ -678,16 +762,66 @@ level	page_num	block_num	par_num	line_num	word_num	left	top	width	height	conf	te
             @(Get-Favorite -path $script:testDrivePath).Count | Should -Be 3
         }
 
-        It 'returns an empty array for malformed JSON' {
+        It 'warns and returns an empty array for malformed JSON without changing the file' {
             '{not-valid-json' | Set-Content -Path $script:testDrivePath -Encoding UTF8
+            Mock Write-Warning
 
             @(Get-Favorite -path $script:testDrivePath).Count | Should -Be 0
+            (Get-Content -LiteralPath $script:testDrivePath -Raw) | Should -Match 'not-valid-json'
+            Should -Invoke Write-Warning -Times 1 -Exactly -ParameterFilter {
+                $Message -match 'Favorites file.*malformed or invalid.*left unchanged'
+            }
         }
 
-        It 'returns an empty array when JSON is valid but not a favorites array' {
+        It 'warns and returns an empty array when JSON is valid but not a favorites array' {
             '"hello"' | Set-Content -Path $script:testDrivePath -Encoding UTF8
+            Mock Write-Warning
 
             @(Get-Favorite -path $script:testDrivePath).Count | Should -Be 0
+            Should -Invoke Write-Warning -Times 1 -Exactly
+        }
+
+        It 'recovers favorites from the last-known-good backup' {
+            '{not-valid-json' | Set-Content -Path $script:testDrivePath -Encoding UTF8
+            @'
+[
+  { "ICAO": "EHAM", "Channel": "Tower", "Count": 2, "LastUsed": "2026-08-18T12:00:00Z" }
+]
+'@ | Set-Content -Path ($script:testDrivePath + '.bak') -Encoding UTF8
+            Mock Write-Warning
+
+            $favorites = @(Get-Favorite -path $script:testDrivePath)
+
+            $favorites.Count | Should -Be 1
+            $favorites[0].ICAO | Should -Be 'EHAM'
+            $favorites[0].Count | Should -Be 2
+            Should -Invoke Write-Warning -Times 1 -Exactly -ParameterFilter {
+                $Message -match 'Recovered favorites from backup'
+            }
+        }
+
+        It 'writes favorites atomically and retains the previous valid file' {
+            Add-Favorite -path $script:testDrivePath -ICAO 'KLAX' -Channel 'Tower' -maxEntries 10
+            Add-Favorite -path $script:testDrivePath -ICAO 'EHAM' -Channel 'Ground' -maxEntries 10
+
+            $activeFavorites = @(Get-Content -LiteralPath $script:testDrivePath -Raw | ConvertFrom-Json)
+            $backupFavorites = @(Get-Content -LiteralPath ($script:testDrivePath + '.bak') -Raw | ConvertFrom-Json)
+
+            $activeFavorites.Count | Should -Be 2
+            $backupFavorites.Count | Should -Be 1
+            $backupFavorites[0].ICAO | Should -Be 'KLAX'
+        }
+
+        It 'preserves malformed favorites before a later write' {
+            '{not-valid-json' | Set-Content -Path $script:testDrivePath -Encoding UTF8
+            Mock Write-Warning
+
+            Add-Favorite -path $script:testDrivePath -ICAO 'KLAX' -Channel 'Tower' -maxEntries 10
+
+            @(Get-Favorite -path $script:testDrivePath).Count | Should -Be 1
+            $corruptBackups = @(Get-ChildItem -LiteralPath $TestDrive -Filter 'favorites.json.corrupt-*.bak')
+            $corruptBackups.Count | Should -Be 1
+            (Get-Content -LiteralPath $corruptBackups[0].FullName -Raw) | Should -Match 'not-valid-json'
         }
     }
 

--- a/tests/lofiatc.Tests.ps1
+++ b/tests/lofiatc.Tests.ps1
@@ -729,6 +729,11 @@ level	page_num	block_num	par_num	line_num	word_num	left	top	width	height	conf	te
             if (Test-Path $script:testDrivePath) {
                 Remove-Item $script:testDrivePath -Force
             }
+            if (Test-Path ($script:testDrivePath + '.bak')) {
+                Remove-Item ($script:testDrivePath + '.bak') -Force
+            }
+            Get-ChildItem -LiteralPath $TestDrive -Filter 'favorites.json.corrupt-*.bak' |
+                Remove-Item -Force
         }
 
         It 'returns an empty array when favorites file does not exist' {
@@ -831,6 +836,9 @@ level	page_num	block_num	par_num	line_num	word_num	left	top	width	height	conf	te
             $script:addedFavoritesPath = Join-Path $TestDrive 'added_favorites.json'
             if (Test-Path $script:addedFavoritesPath) {
                 Remove-Item $script:addedFavoritesPath -Force
+            }
+            if (Test-Path ($script:addedFavoritesPath + '.bak')) {
+                Remove-Item ($script:addedFavoritesPath + '.bak') -Force
             }
         }
 


### PR DESCRIPTION
Closes #56

## What changed

- route favorites, default configuration, and named-profile writes through one validated temporary-file replacement path
- retain the previous valid JSON as a `.bak` last-known-good copy
- warn on malformed or schema-invalid favorites/configuration data and recover reads from a valid backup
- preserve damaged active JSON in a uniquely named `.corrupt-*.bak` file before a later save replaces it
- clean staged files and leave the active file unchanged when replacement fails
- document the recovery behavior and add regression coverage for writes, backups, malformed data, recovery, and failed replacement

## Why

Favorites previously treated malformed JSON as an empty list, so the next update could silently discard recoverable user data. Normal configuration saves also wrote directly to the active file. This makes both persistence paths safer and consistent.

## Validation

- `git diff --cached --check` passed before commit
- Pester could not be run locally because this container does not have `pwsh` or Windows PowerShell; the draft PR CI matrix will validate PowerShell 7 on Windows, Ubuntu, and macOS plus Windows PowerShell 5.1
