### PR TITLE
Add resilient network handling and airport data caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ lofiatc -CheckDependencies -Player VLC
 - supported media players found in `PATH`
 - optional tools like `fzf`, `yt-dlp`, and `youtube-dl`
 - local files such as `config.json`, `favorites.json`, and ATC source CSVs
-- optional network/service checks for airport and weather endpoints
+- the airport metadata cache and optional network/service checks for airport and weather endpoints
 
 The installer copies the app files to a per-user install directory and installs a small PowerShell module command named `lofiatc`. That command preserves PowerShell help and tab completion on Windows, macOS, and Linux:
 ```powershell
@@ -368,6 +368,12 @@ lofiatc -LoadConfig -OpenRadar
 
 Configuration and profile files are written through a validated temporary file before replacement. When an existing file is valid, its previous contents are retained in a neighboring `.bak` file. If the active JSON becomes malformed, LofiATC warns and attempts to load the last-known-good backup without modifying the damaged file. A later save preserves malformed JSON in a uniquely named `.corrupt-*.bak` file before replacing it.
 
+### Offline airport data
+
+Airport metadata used by the map, nearby-airport selection, local time, and sunrise/sunset features is cached as `airport-data-cache.json` in the user data folder. A cache is considered fresh for seven days. After that, LofiATC attempts a bounded refresh and uses the stale last-known-good cache if the service is unavailable. If the active cache is malformed, a valid neighboring `.bak` cache can be used instead.
+
+The first airport-data request still needs network access when no cache exists. Optional IP location, METAR, and sunrise/sunset failures return unavailable data without stopping unrelated ATC or lofi playback. Run `lofiatc -Verbose` to see whether airport data came from the live service, active cache, backup fallback, or was unavailable; `lofiatc -CheckDependencies` reports the current cache path, source, and age.
+
 ### Named profiles
 
 Named profiles let you keep several reusable setups while preserving the existing `config.json` behavior. Profile names are 1–64 letters, numbers, underscores, or hyphens and must start with a letter or number.
@@ -505,6 +511,7 @@ lofiatc -CheckDependencies
 - optional tools such as `fzf`, `yt-dlp`, `youtube-dl`, `ffmpeg`, and Tesseract OCR
 - ATC source CSV availability
 - `config.json` / `favorites.json` presence and JSON validity
+- airport metadata cache availability, source, path, and age
 - optional browser/map helpers such as `xdg-open` on Linux or `open` on macOS
 - optional network/service checks for airport and weather data sources
 
@@ -540,6 +547,7 @@ lofiatc -CheckDependencies
 - **yt-dlp errors:** update it to the latest version and retry.
 - **YouTube or webcam streams not loading in player:** make sure `yt-dlp` is up to date; recent upstream changes may require extra packages depending on your platform.
 - **Map opens slowly:** use `-ShowMap -NoWeather` to skip live weather fetch and load faster.
+- **Airport data is unavailable:** the first map or nearby-airport request needs network access. After a successful request, LofiATC keeps a seven-day user cache and can use stale data during an outage. Run `lofiatc -CheckDependencies` for its status.
 - **Map opens but clicking a channel does nothing:** make sure the PowerShell window is still running in the background; the browser talks back to a temporary local listener started by the script.
 - **Map selection feels stuck:** return to the terminal and press `Q` to cancel the map selection flow.
 - **Nearby airport lookup fails:** location access may be unavailable on your device; the script falls back to IP-based lookup, which is approximate.

--- a/install.ps1
+++ b/install.ps1
@@ -133,7 +133,7 @@ Function Get-LofiATCSourceCommit {
         $escapedRef = [System.Uri]::EscapeDataString($Ref)
         $commit = Invoke-RestMethod -Uri "https://api.github.com/repos/$Repository/commits/$escapedRef" -Headers @{
             Accept = 'application/vnd.github+json'
-        }
+        } -TimeoutSec 10 -ErrorAction Stop
         if ($commit.sha) {
             return [string]$commit.sha
         }
@@ -498,7 +498,7 @@ try {
         else {
             "https://github.com/$Repository/archive/refs/heads/$Ref.zip"
         }
-        Invoke-WebRequest -Uri $archiveUrl -OutFile $zipPath -UseBasicParsing
+        Invoke-WebRequest -Uri $archiveUrl -OutFile $zipPath -UseBasicParsing -TimeoutSec 60 -ErrorAction Stop
         Expand-Archive -Path $zipPath -DestinationPath $tempRoot -Force
 
         $sourceRoot = Get-ChildItem -Path $tempRoot -Directory | Select-Object -First 1 -ExpandProperty FullName

--- a/modules/LofiATC.Core.psm1
+++ b/modules/LofiATC.Core.psm1
@@ -22,6 +22,12 @@ Function Get-LofiATCGenreMap {
 Function Initialize-LofiATCState {
     $script:OnWindows = $env:OS -eq 'Windows_NT'
     $script:AirportData = $null
+    $script:AirportDataStatus = [pscustomobject]@{
+        Source        = 'Unavailable'
+        CachePath     = $null
+        CacheAgeHours = $null
+        IsStale       = $false
+    }
 
     $script:IanaToWindowsMap = @{
         "Etc/UTC"                        = "UTC"
@@ -1332,6 +1338,10 @@ Function Get-NearbyAirports {
         Get-AirportInfo -ICAO "KLAX" | Out-Null
     }
 
+    if (-not $script:AirportData) {
+        throw 'Airport metadata is unavailable, so nearby-airport selection cannot continue. Retry when online after a cache has been created.'
+    }
+
     $allAirports = $script:AirportData.PSObject.Properties | ForEach-Object {
         $_.Value
     }
@@ -1702,12 +1712,31 @@ Function Test-LofiATCDependencies {
             -Details $(if ($ShowMap) { 'Uses Start-Process on Windows.' } else { 'Not requested.' })
     }
 
+    $airportCachePath = Get-LofiATCAirportCachePath
+    $airportCache = Read-LofiATCAirportCache -Path $airportCachePath
+    $results += Add-DependencyResult `
+        -Name 'Airport data cache' `
+        -Required $false `
+        -Status $(if ($airportCache) { 'OK' } else { 'Warning' }) `
+        -Details $(if ($airportCache) {
+            '{0} cache available at {1}; age {2:N1} hours.' -f $airportCache.Source, $airportCache.Path, $airportCache.Age.TotalHours
+        } else {
+            "No valid cache at $airportCachePath; the first airport metadata request requires network access."
+        }) `
+        -Category 'Data'
+
     $airportDbOk = Test-UrlReachable -Url 'https://raw.githubusercontent.com/rominjun/Airports/master/airports.json'
     $results += Add-DependencyResult `
         -Name 'Airport database service' `
         -Required $false `
         -Status $(if ($airportDbOk) { 'OK' } else { 'Warning' }) `
-        -Details 'Used for airport metadata.' `
+        -Details $(if ($airportDbOk) {
+            'Reachable; live data will refresh when the cache is older than seven days.'
+        } elseif ($airportCache) {
+            'Unavailable; cached airport metadata can be used.'
+        } else {
+            'Unavailable and no valid cache exists.'
+        }) `
         -Category 'Network'
 
     $noaaOk = Test-UrlReachable -Url 'https://aviationweather.gov/api/data/metar?ids=KLAX'

--- a/modules/LofiATC.Map.psm1
+++ b/modules/LofiATC.Map.psm1
@@ -557,6 +557,10 @@ Function Select-ATCMap {
         Get-AirportInfo -ICAO "KLAX" | Out-Null
     }
 
+    if (-not $script:AirportData) {
+        throw 'Airport metadata is unavailable, so the interactive map cannot be generated. Retry when online after a cache has been created.'
+    }
+
     $server = Start-ATCMapServer
     $port = $server.Port
     $listener = $server.Listener
@@ -1291,7 +1295,9 @@ Function Select-ATCFromMap {
                     return $selection
                 }
             }
-            catch {}
+            catch {
+                Write-Verbose "Map selection request handling failed. $_"
+            }
         }
 
         throw "Timed out waiting for a map selection after $TimeoutSeconds seconds."
@@ -1492,7 +1498,7 @@ Function Start-PersistentATCMapSession {
         Stop-ManagedProcess -Process $script:CurrentWebcamProcess
         Stop-ManagedProcess -Process $script:CurrentLofiProcess
 
-        try { $Listener.Stop() } catch {}
-        try { $Listener.Close() } catch {}
+        try { $Listener.Stop() } catch { Write-Verbose "Could not stop the map listener cleanly. $_" }
+        try { $Listener.Close() } catch { Write-Verbose "Could not close the map listener cleanly. $_" }
     }
 }

--- a/modules/LofiATC.Weather.psm1
+++ b/modules/LofiATC.Weather.psm1
@@ -18,7 +18,7 @@ Function Get-METAR-TAF {
     foreach ($code in $icaoList) {
         $url = "https://aviationweather.gov/api/data/metar?ids=$code"
         try {
-            $response = Invoke-WebRequest -Uri $url -UseBasicParsing -Verbose:$false
+            $response = Invoke-WebRequest -Uri $url -UseBasicParsing -TimeoutSec 8 -ErrorAction Stop -Verbose:$false
             $raw = $response.Content.Trim()
             if ($raw -match "\b$code\b" -and $raw -match '\b\d{6}Z\b') {
                 $used = $code; $source = 'NOAA'; $sourceUrl = 'https://aviationweather.gov'
@@ -34,7 +34,7 @@ Function Get-METAR-TAF {
 
         try {
             $vatsimUrl = "https://metar.vatsim.net/metar.php?id=$code"
-            $response = Invoke-WebRequest -Uri $vatsimUrl -UseBasicParsing -Verbose:$false
+            $response = Invoke-WebRequest -Uri $vatsimUrl -UseBasicParsing -TimeoutSec 8 -ErrorAction Stop -Verbose:$false
             $raw = $response.Content.Trim()
             if ($raw -match "\b$code\b" -and $raw -match '\b\d{6}Z\b') {
                 $used = $code; $source = 'VATSIM'; $sourceUrl = 'https://metar.vatsim.net'
@@ -50,7 +50,7 @@ Function Get-METAR-TAF {
     }
 
     if (-not $raw) {
-        Write-Error "Failed to fetch METAR/TAF data for $ICAO and fallbacks."
+        Write-Verbose "METAR data is unavailable for $ICAO and its configured fallbacks."
         return [pscustomobject]@{ Report = "METAR/TAF data unavailable."; ICAO = $ICAO; DistanceKm = $null; Source = $null; SourceUrl = $null }
     }
 
@@ -244,21 +244,211 @@ Function ConvertTo-TimeZoneInfo {
     }
 }
 
-# Function to fetch airport information from a cached dataset, loading it from a remote source if not already loaded, and return the info for a given ICAO code
-Function Get-AirportInfo {
-    param(
-        [string]$ICAO
+# Functions to load and cache the airport metadata dataset used by maps, nearby selection, and local-time features
+Function Get-LofiATCAirportCachePath {
+    return (Join-Path (Get-LofiATCUserDataPath) 'airport-data-cache.json')
+}
+
+Function Test-LofiATCAirportDataset {
+    param([object]$Dataset)
+
+    if ($null -eq $Dataset) {
+        return $false
+    }
+
+    $airportProperties = @($Dataset.PSObject.Properties)
+    if ($airportProperties.Count -eq 0) {
+        return $false
+    }
+
+    $sample = $airportProperties[0].Value
+    return (
+        $null -ne $sample -and
+        $sample.PSObject.Properties['icao'] -and
+        $sample.PSObject.Properties['lat'] -and
+        $sample.PSObject.Properties['lon']
+    )
+}
+
+Function Read-LofiATCAirportCacheFile {
+    param([string]$Path)
+
+    $cache = Get-Content -LiteralPath $Path -Raw | ConvertFrom-Json
+    if ($null -eq $cache -or
+        -not $cache.PSObject.Properties['Version'] -or
+        [int]$cache.Version -ne 1 -or
+        -not $cache.PSObject.Properties['RetrievedAtUtc'] -or
+        -not $cache.PSObject.Properties['Airports'] -or
+        -not (Test-LofiATCAirportDataset -Dataset $cache.Airports)) {
+        throw 'The airport cache has an unsupported or invalid schema.'
+    }
+
+    $retrievedAtUtc = [datetime]::MinValue
+    $parsed = [datetime]::TryParse(
+        [string]$cache.RetrievedAtUtc,
+        [System.Globalization.CultureInfo]::InvariantCulture,
+        [System.Globalization.DateTimeStyles]::AssumeUniversal,
+        [ref]$retrievedAtUtc
+    )
+    if (-not $parsed) {
+        throw 'The airport cache timestamp is invalid.'
+    }
+
+    $retrievedAtUtc = $retrievedAtUtc.ToUniversalTime()
+    $age = [datetime]::UtcNow - $retrievedAtUtc
+    if ($age.TotalSeconds -lt 0) {
+        $age = [timespan]::Zero
+    }
+
+    return [pscustomobject]@{
+        Airports       = $cache.Airports
+        RetrievedAtUtc = $retrievedAtUtc
+        Age            = $age
+    }
+}
+
+Function Read-LofiATCAirportCache {
+    param([string]$Path)
+
+    $candidates = @(
+        [pscustomobject]@{ Path = $Path; Source = 'Cached' },
+        [pscustomobject]@{ Path = ($Path + '.bak'); Source = 'Fallback' }
     )
 
-    if (-not $script:AirportData) {
+    foreach ($candidate in $candidates) {
+        if (-not (Test-Path -LiteralPath $candidate.Path)) {
+            continue
+        }
+
         try {
-            $script:AirportData = Invoke-RestMethod -Uri 'https://raw.githubusercontent.com/rominjun/Airports/master/airports.json' -Method Get
+            $cache = Read-LofiATCAirportCacheFile -Path $candidate.Path
+            return [pscustomobject]@{
+                Airports       = $cache.Airports
+                RetrievedAtUtc = $cache.RetrievedAtUtc
+                Age            = $cache.Age
+                Path           = $candidate.Path
+                Source         = $candidate.Source
+            }
         }
         catch {
-            Write-Error "Failed to load airport database. Exception: $_"; return $null
+            Write-Verbose "Airport cache '$($candidate.Path)' is unavailable: $($_.Exception.Message)"
         }
     }
-    $info = $script:AirportData.$ICAO
+
+    return $null
+}
+
+Function Save-LofiATCAirportCache {
+    param(
+        [object]$AirportData,
+        [string]$Path
+    )
+
+    $cache = [ordered]@{
+        Version        = 1
+        RetrievedAtUtc = [datetime]::UtcNow.ToString('o', [System.Globalization.CultureInfo]::InvariantCulture)
+        SourceUrl      = 'https://raw.githubusercontent.com/rominjun/Airports/master/airports.json'
+        Airports       = $AirportData
+    }
+
+    Write-LofiATCJsonFileAtomically -InputObject $cache -Path $Path -FileValidator {
+        param($CandidatePath)
+        $null = Read-LofiATCAirportCacheFile -Path $CandidatePath
+    }
+}
+
+Function Get-LofiATCAirportData {
+    param(
+        [int]$CacheMaxAgeDays = 7,
+        [int]$TimeoutSec = 10
+    )
+
+    if ($script:AirportData) {
+        return $script:AirportData
+    }
+
+    $cachePath = Get-LofiATCAirportCachePath
+    $cached = Read-LofiATCAirportCache -Path $cachePath
+    if ($cached -and $cached.Age.TotalDays -le $CacheMaxAgeDays) {
+        $script:AirportData = $cached.Airports
+        $script:AirportDataStatus = [pscustomobject]@{
+            Source        = $cached.Source
+            CachePath     = $cached.Path
+            CacheAgeHours = [math]::Round($cached.Age.TotalHours, 1)
+            IsStale       = $false
+        }
+
+        if ($cached.Source -eq 'Fallback') {
+            Write-Warning "The active airport cache is unavailable. Using last-known-good backup '$($cached.Path)'."
+        }
+        Write-Verbose "Airport data source: $($cached.Source.ToLowerInvariant()) cache '$($cached.Path)' (age $($script:AirportDataStatus.CacheAgeHours) hours)."
+        return $script:AirportData
+    }
+
+    $sourceUrl = 'https://raw.githubusercontent.com/rominjun/Airports/master/airports.json'
+    try {
+        $airportData = Invoke-RestMethod -Uri $sourceUrl -Method Get -TimeoutSec $TimeoutSec -ErrorAction Stop
+        if (-not (Test-LofiATCAirportDataset -Dataset $airportData)) {
+            throw 'The downloaded airport database has an invalid schema.'
+        }
+
+        $script:AirportData = $airportData
+        $script:AirportDataStatus = [pscustomobject]@{
+            Source        = 'Live'
+            CachePath     = $cachePath
+            CacheAgeHours = 0
+            IsStale       = $false
+        }
+
+        try {
+            Save-LofiATCAirportCache -AirportData $airportData -Path $cachePath
+        }
+        catch {
+            Write-Warning "Airport data was loaded live but could not be cached at '$cachePath': $($_.Exception.Message)"
+        }
+
+        Write-Verbose "Airport data source: live '$sourceUrl'."
+        return $script:AirportData
+    }
+    catch {
+        if ($cached) {
+            $script:AirportData = $cached.Airports
+            $script:AirportDataStatus = [pscustomobject]@{
+                Source        = $cached.Source
+                CachePath     = $cached.Path
+                CacheAgeHours = [math]::Round($cached.Age.TotalHours, 1)
+                IsStale       = $true
+            }
+            Write-Warning "Airport database refresh failed; using stale last-known-good data from '$($cached.Path)'. $($_.Exception.Message)"
+            Write-Verbose "Airport data source: stale $($cached.Source.ToLowerInvariant()) cache."
+            return $script:AirportData
+        }
+
+        $script:AirportDataStatus = [pscustomobject]@{
+            Source        = 'Unavailable'
+            CachePath     = $cachePath
+            CacheAgeHours = $null
+            IsStale       = $false
+        }
+        Write-Error "Airport database is unavailable and no valid cache exists. Check your connection and retry. $($_.Exception.Message)"
+        return $null
+    }
+}
+
+Function Get-LofiATCAirportDataStatus {
+    return $script:AirportDataStatus
+}
+
+# Function to fetch airport information from the in-memory, user-cached, or remote dataset
+Function Get-AirportInfo {
+    param([string]$ICAO)
+
+    $airportData = Get-LofiATCAirportData
+    if (-not $airportData) {
+        return $null
+    }
+
+    $info = $airportData.$ICAO
     if (-not $info) {
         Write-Error "Airport info not found for $ICAO."
     }
@@ -279,7 +469,8 @@ Function Get-AirportDateTime {
         return "$($local.ToString('dd MMMM yyyy HH:mm', [System.Globalization.CultureInfo]::InvariantCulture)) LT"
     }
     catch {
-        Write-Error "Date and time not found for $ICAO. Exception: $_"; return "Date/time data unavailable"
+        Write-Verbose "Airport date/time is unavailable for $ICAO. $_"
+        return "Date/time data unavailable"
     }
 }
 
@@ -300,7 +491,7 @@ Function Get-AirportSunriseSunset {
         $tzInfo = ConvertTo-TimeZoneInfo -IanaId $tz
 
         $uri = "https://api.sunrise-sunset.org/json?lat=$lat&lng=$lon&formatted=0&tzid=$tz"
-        $sunInfo = Invoke-RestMethod -Uri $uri -Method Get
+        $sunInfo = Invoke-RestMethod -Uri $uri -Method Get -TimeoutSec 8 -ErrorAction Stop
         $sunriseOffset = [datetimeoffset]::Parse($sunInfo.results.sunrise, [cultureinfo]::InvariantCulture)
         $sunsetOffset = [datetimeoffset]::Parse($sunInfo.results.sunset, [cultureinfo]::InvariantCulture)
 
@@ -309,7 +500,10 @@ Function Get-AirportSunriseSunset {
             Sunset  = [System.TimeZoneInfo]::ConvertTime($sunsetOffset, $tzInfo).ToString('HH:mm')
         }
     }
-    catch { Write-Error "Failed to fetch data for $ICAO. Exception: $_"; return @{ Sunrise = "Data unavailable"; Sunset = "Data unavailable" } }
+    catch {
+        Write-Verbose "Sunrise/sunset data is unavailable for $ICAO. $_"
+        return @{ Sunrise = "Data unavailable"; Sunset = "Data unavailable" }
+    }
 }
 
 # Function to determine how long ago the METAR report was updated based on the timestamp in the METAR string, handling time zone and date rollovers correctly
@@ -346,7 +540,7 @@ Function Get-METAR-LastUpdatedTime {
         }
     }
     catch {
-        Write-Error "Failed to fetch the last updated time for $ICAO. Exception: $_"
+        Write-Verbose "METAR last-updated time is unavailable for $ICAO. $_"
         return "Last updated time unavailable."
     }
 }
@@ -382,7 +576,9 @@ Function Get-MapWeatherData {
     try {
         [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
     }
-    catch {}
+    catch {
+        Write-Verbose "Could not enable TLS 1.2 explicitly; continuing with the platform default. $_"
+    }
 
     $allIcaosToFetch = [System.Collections.Generic.HashSet[string]]::new()
 
@@ -410,7 +606,7 @@ Function Get-MapWeatherData {
             $noaaTimer = [System.Diagnostics.Stopwatch]::StartNew()
             try {
                 $stats.NoaaRequests++
-                $wxData = Invoke-RestMethod -Uri "https://aviationweather.gov/api/data/metar?ids=$chunk&format=json" -Method Get -TimeoutSec 12
+                $wxData = Invoke-RestMethod -Uri "https://aviationweather.gov/api/data/metar?ids=$chunk&format=json" -Method Get -TimeoutSec 12 -ErrorAction Stop
             }
             finally {
                 $noaaTimer.Stop()
@@ -452,7 +648,7 @@ Function Get-MapWeatherData {
                 $vatsimTimer = [System.Diagnostics.Stopwatch]::StartNew()
                 try {
                     $stats.VatsimRequests++
-                    $vRes = Invoke-WebRequest -Uri "https://metar.vatsim.net/metar.php?id=$mIcao" -UseBasicParsing -TimeoutSec 2 -ErrorAction SilentlyContinue
+                    $vRes = Invoke-WebRequest -Uri "https://metar.vatsim.net/metar.php?id=$mIcao" -UseBasicParsing -TimeoutSec 2 -ErrorAction Stop
                     $vRaw = if ($null -ne $vRes -and $vRes.PSObject.Properties['Content']) {
                         [string]$vRes.Content
                     }
@@ -516,7 +712,9 @@ Function Get-MapWeatherData {
                     $stats.VatsimStations++
                 }
             }
-            catch {}
+            catch {
+                Write-Verbose "VATSIM METAR fetch failed for $mIcao. $_"
+            }
         }
     }
 

--- a/packaging/LofiATC/LofiATC.psm1
+++ b/packaging/LofiATC/LofiATC.psm1
@@ -101,7 +101,7 @@ Function Resolve-LofiATCCommit {
     $commitUrl = "https://api.github.com/repos/$Repository/commits/$escapedRef"
     $commit = Invoke-RestMethod -Uri $commitUrl -Headers @{
         Accept = 'application/vnd.github+json'
-    }
+    } -TimeoutSec 10 -ErrorAction Stop
 
     if (-not $commit.sha) {
         throw "GitHub did not return a commit hash for ref '$Ref'."
@@ -290,7 +290,7 @@ Function Update-LofiATCSources {
         throw "Install root not found: $InstallRoot"
     }
 
-    Invoke-WebRequest -Uri $sourceUrl -OutFile $tempPath -UseBasicParsing
+    Invoke-WebRequest -Uri $sourceUrl -OutFile $tempPath -UseBasicParsing -TimeoutSec 30 -ErrorAction Stop
 
     try {
         if ($sourceCommit) {
@@ -372,7 +372,7 @@ Function Update-LofiATC {
     }
 
     try {
-        Invoke-WebRequest -Uri $installerUrl -OutFile $tempInstaller -UseBasicParsing
+        Invoke-WebRequest -Uri $installerUrl -OutFile $tempInstaller -UseBasicParsing -TimeoutSec 15 -ErrorAction Stop
         $installerParameters = @{
             InstallRoot           = $InstallRoot
             Ref                   = $Ref

--- a/tests/lofiatc.Tests.ps1
+++ b/tests/lofiatc.Tests.ps1
@@ -1445,6 +1445,7 @@ KLAX,Tower,http://example.com/stream
             'ICAO,Channel Description,Stream URL' | Set-Content -Path (Join-Path $script:scriptDir 'atc_sources.csv') -Encoding UTF8
 
             Mock Test-UrlReachable { $true }
+            Mock Read-LofiATCAirportCache { $null }
         }
 
         It 'treats fzf as required only when UseFZF is set' {
@@ -1607,6 +1608,9 @@ KLAX,Tower,http://example.com/stream
             $result.City | Should -Be 'Los Angeles'
             $result.Country | Should -Be 'United States'
             $result.Source | Should -Be 'IP'
+            Should -Invoke Invoke-RestMethod -Times 1 -Exactly -ParameterFilter {
+                $TimeoutSec -eq 5 -and $ErrorAction -eq 'Stop'
+            }
         }
 
         It 'returns null when the provider call fails' {
@@ -1668,7 +1672,9 @@ KLAX,Tower,http://example.com/stream
 
             Get-MapWeatherData -AtcSources $sources | Out-Null
 
-            Should -Invoke Invoke-RestMethod -Times 3 -Exactly
+            Should -Invoke Invoke-RestMethod -Times 3 -Exactly -ParameterFilter {
+                $TimeoutSec -eq 12 -and $ErrorAction -eq 'Stop'
+            }
             Should -Not -Invoke Invoke-WebRequest
         }
 
@@ -1703,7 +1709,9 @@ KLAX,Tower,http://example.com/stream
 
             $result = Get-MapWeatherData -AtcSources $sources -UseVatsimFallback
 
-            Should -Invoke Invoke-WebRequest -Times 2 -Exactly
+            Should -Invoke Invoke-WebRequest -Times 2 -Exactly -ParameterFilter {
+                $TimeoutSec -eq 2 -and $ErrorAction -eq 'Stop'
+            }
             $result.WeatherMap.ContainsKey('KAAA') | Should -BeTrue
             $result.WeatherMap['KAAA'].Source | Should -Be 'VATSIM'
             $result.WeatherMap.ContainsKey('KCCC') | Should -BeTrue
@@ -1775,21 +1783,112 @@ KLAX,Tower,http://example.com/stream
         }
     }
 
-    Context 'Get-AirportInfo remote failure behavior' {
+    Context 'Get-AirportInfo resilient cache behavior' {
         BeforeEach {
+            $script:previousAirportUserDataPath = $env:LOFIATC_USER_DATA
+            $env:LOFIATC_USER_DATA = Join-Path $TestDrive ('airport-data-' + [guid]::NewGuid().ToString('N'))
             $script:AirportData = $null
+            $script:AirportDataStatus = $null
+            $script:testAirportData = [pscustomobject]@{
+                KLAX = [pscustomobject]@{
+                    icao = 'KLAX'
+                    name = 'Los Angeles International'
+                    tz   = 'America/Los_Angeles'
+                    lat  = 33.9416
+                    lon  = -118.4085
+                }
+            }
         }
 
-        It 'returns null when remote airport database fetch fails' {
+        AfterEach {
+            if ($null -eq $script:previousAirportUserDataPath) {
+                Remove-Item Env:\LOFIATC_USER_DATA -ErrorAction SilentlyContinue
+            }
+            else {
+                $env:LOFIATC_USER_DATA = $script:previousAirportUserDataPath
+            }
+            $script:AirportData = $null
+            $script:AirportDataStatus = $null
+        }
+
+        It 'downloads and caches airport data with a bounded request' {
+            Mock Invoke-RestMethod { $script:testAirportData }
+
+            $result = Get-AirportInfo -ICAO 'KLAX'
+            $cachePath = Get-LofiATCAirportCachePath
+
+            $result.icao | Should -Be 'KLAX'
+            Test-Path -LiteralPath $cachePath | Should -BeTrue
+            $script:AirportDataStatus.Source | Should -Be 'Live'
+            $script:AirportDataStatus.IsStale | Should -BeFalse
+            Should -Invoke Invoke-RestMethod -Times 1 -Exactly -ParameterFilter {
+                $TimeoutSec -eq 10 -and $ErrorAction -eq 'Stop'
+            }
+        }
+
+        It 'uses a fresh user cache without making a remote request' {
+            $cachePath = Get-LofiATCAirportCachePath
+            Save-LofiATCAirportCache -AirportData $script:testAirportData -Path $cachePath
+            $script:AirportData = $null
+            Mock Invoke-RestMethod { throw 'Should not be called' }
+
+            $result = Get-AirportInfo -ICAO 'KLAX'
+
+            $result.icao | Should -Be 'KLAX'
+            $script:AirportDataStatus.Source | Should -Be 'Cached'
+            $script:AirportDataStatus.IsStale | Should -BeFalse
+            Should -Not -Invoke Invoke-RestMethod
+        }
+
+        It 'uses stale last-known-good data when refresh fails' {
+            $cachePath = Get-LofiATCAirportCachePath
+            $cache = [ordered]@{
+                Version        = 1
+                RetrievedAtUtc = [datetime]::UtcNow.AddDays(-8).ToString('o', [System.Globalization.CultureInfo]::InvariantCulture)
+                SourceUrl      = 'https://example.test/airports.json'
+                Airports       = $script:testAirportData
+            }
+            Write-LofiATCJsonFileAtomically -InputObject $cache -Path $cachePath
+            Mock Invoke-RestMethod { throw 'network failure' }
+            Mock Write-Warning {}
+
+            $result = Get-AirportInfo -ICAO 'KLAX'
+
+            $result.icao | Should -Be 'KLAX'
+            $script:AirportDataStatus.Source | Should -Be 'Cached'
+            $script:AirportDataStatus.IsStale | Should -BeTrue
+            Should -Invoke Write-Warning -Times 1 -Exactly
+        }
+
+        It 'recovers from a last-known-good backup when the active cache is invalid' {
+            $cachePath = Get-LofiATCAirportCachePath
+            Save-LofiATCAirportCache -AirportData $script:testAirportData -Path $cachePath
+            Copy-Item -LiteralPath $cachePath -Destination ($cachePath + '.bak')
+            Set-Content -LiteralPath $cachePath -Value '{ invalid json' -Encoding UTF8
+            Mock Invoke-RestMethod { throw 'Should not be called' }
+            Mock Write-Warning {}
+
+            $result = Get-AirportInfo -ICAO 'KLAX'
+
+            $result.icao | Should -Be 'KLAX'
+            $script:AirportDataStatus.Source | Should -Be 'Fallback'
+            $script:AirportDataStatus.IsStale | Should -BeFalse
+            Should -Invoke Write-Warning -Times 1 -Exactly
+            Should -Not -Invoke Invoke-RestMethod
+        }
+
+        It 'returns null when the first download fails and no valid cache exists' {
             Mock Invoke-RestMethod { throw 'network failure' }
             Mock Write-Error {}
 
             $result = Get-AirportInfo -ICAO 'KLAX'
 
             $result | Should -Be $null
+            $script:AirportDataStatus.Source | Should -Be 'Unavailable'
+            Test-Path -LiteralPath (Get-LofiATCAirportCachePath) | Should -BeFalse
         }
 
-        It 'returns airport info from cached data without remote fetch' {
+        It 'returns airport info from in-memory data without remote fetch' {
             $script:AirportData = [pscustomobject]@{
                 KLAX = [pscustomobject]@{
                     icao = 'KLAX'
@@ -1878,6 +1977,9 @@ KLAX,Tower,http://example.com/stream
             $result.Report | Should -Match '^KSNA '
             $result.DistanceKm | Should -BeGreaterThan 0
             $result.DistanceNm | Should -BeGreaterThan 0
+            Should -Invoke Invoke-WebRequest -ParameterFilter {
+                $TimeoutSec -eq 8 -and $ErrorAction -eq 'Stop'
+            }
         }
 
         It 'returns the unavailable object when all sources fail' {


### PR DESCRIPTION
## What changed

- cache validated airport metadata in the user data directory for seven days
- fall back to stale active data or a last-known-good backup when refreshes fail
- add explicit timeouts and terminating request errors to every runtime, installer, and updater HTTP call
- replace silent runtime request catches with verbose diagnostics while keeping optional weather and metadata failures non-blocking
- report airport cache availability, source, path, and age through the dependency check

## Why

Airport metadata powers maps, nearby selection, local time, and sunrise information. Previously, a slow or unavailable upstream service had no bounded timeout or persistent fallback. Optional service errors could also create noisy errors during otherwise valid playback.

## Validation

- `git diff --check`
- added mocked Pester coverage for live downloads, fresh cache reuse, stale fallback, backup recovery, cold-start failure, and bounded request parameters
- local Pester execution was unavailable because this host does not have `pwsh` or Windows PowerShell; the PR CI matrix will perform the PowerShell validation

Closes #57
